### PR TITLE
Fixed Typo in help message for help...

### DIFF
--- a/commands/plugin_bot.go
+++ b/commands/plugin_bot.go
@@ -70,7 +70,7 @@ func (p *Plugin) Prefix(data *dcmd.Data) string {
 var cmdHelp = &YAGCommand{
 	Name:        "Help",
 	Aliases:     []string{"commands", "h", "how", "command"},
-	Description: "Shows help abut all or one specific command",
+	Description: "Shows help about all or one specific command",
 	CmdCategory: CategoryGeneral,
 	RunInDM:     true,
 	Arguments: []*dcmd.ArgDef{


### PR DESCRIPTION
## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)

- -help help // Originally Returned: Shows help abut all or one specific command
- -help help // Now Returns: Shows help about all or one specific command

NOTE: This issue was reported on 01/25/2018 by buthed010203 but was never patched. This patch introduces a fix to the help messages.