### PR TITLE
Block 3rd party invites

### DIFF
--- a/common/util.go
+++ b/common/util.go
@@ -22,7 +22,7 @@ func KeyGuild(guildID int64) string         { return "guild:" + discordgo.StrID(
 func KeyGuildChannels(guildID int64) string { return "channels:" + discordgo.StrID(guildID) }
 
 var DiscordInviteRegex = regexp.MustCompile(`(discord\.gg|discordapp\.com\/invite)(?:\/#)?\/([a-zA-Z0-9-]+)`)
-var ThirdPartyDiscordInviteRegex = regexp.MustCompile(`(discord\.me|invite\.gg)(?:\/#)?\/([a-zA-Z0-9-]+)`)
+var ThirdPartyDiscordInviteRegex = regexp.MustCompile(`(discord\.me|invite\.gg|discord\.io)(?:\/#)?\/([a-zA-Z0-9-]+)`)
 
 type WrappedGuild struct {
 	*discordgo.UserGuild


### PR DESCRIPTION
Blocked discord.io links as they provide 3rd party vanity invite urls