### PR TITLE
quick fix

### DIFF
--- a/automod_legacy/assets/automod_legacy.html
+++ b/automod_legacy/assets/automod_legacy.html
@@ -144,7 +144,7 @@
         <p class="help-block">Built in lists</p>
         <div class="checkbox">
             <label>
-                <input type="checkbox" name="Words.BuiltinSwearWords" {{if .AutomodConfig.Words.BuiltinSwearWords }} checked{{end}}> Ban builtin swear words <a href="https://github.com/jonas747/yagpdb/blob/master/automod/swearwords.go"> (list of swear words here)</a>
+                <input type="checkbox" name="Words.BuiltinSwearWords" {{if .AutomodConfig.Words.BuiltinSwearWords }} checked{{end}}> Ban builtin swear words <a href="https://github.com/jonas747/yagpdb/blob/master/automod_legacy/swearwords.go"> (list of swear words here)</a>
             </label>
         </div>
         <br/>


### PR DESCRIPTION
for automod_legacy's default blacklist words