### PR TITLE
Edited Updates Title in Control Panel

### DIFF
--- a/cmd/yagpdb/templates/cp_selectserver.html
+++ b/cmd/yagpdb/templates/cp_selectserver.html
@@ -1,7 +1,7 @@
 {{define "cp_selectserver"}}
 
 {{template "cp_head" .}}
-<header class="page-header"><h2>Updates and such</h2></header>
+<header class="page-header"><h2>News and updates</h2></header>
 <div class="row">
     <div class="col-lg-7">
         


### PR DESCRIPTION
Changed **Updates and such** to **News and updates** such that it matches the tooltip of the news icon.