### PR TITLE
Add 'ignore edited messages' condition to automod v2

### DIFF
--- a/automod/conditions.go
+++ b/automod/conditions.go
@@ -479,10 +479,6 @@ func (bc *BotCondition) MergeDuplicates(data []interface{}) interface{} {
 
 /////////////////////////////////////////////////////////////////
 
-type MessageEditedData struct {
-	Treshold int
-}
-
 var _ Condition = (*MessageEditedCondition)(nil)
 
 type MessageEditedCondition struct {
@@ -494,7 +490,7 @@ func (mc *MessageEditedCondition) Kind() RulePartType {
 }
 
 func (mc *MessageEditedCondition) DataType() interface{} {
-	return &MessageEditedData{}
+	return nil
 }
 
 func (mc *MessageEditedCondition) Name() string {
@@ -528,7 +524,7 @@ func (mc *MessageEditedCondition) IsMet(data *TriggeredRuleData, settings interf
 		return false, nil
 	}
 
-	// account is older than threshold
+	// message was edited
 	if mc.NewMessage {
 		return false, nil
 	}

--- a/automod/conditions.go
+++ b/automod/conditions.go
@@ -1,9 +1,10 @@
 package automod
 
 import (
+	"time"
+
 	"github.com/jonas747/yagpdb/bot"
 	"github.com/jonas747/yagpdb/common"
-	"time"
 )
 
 type Condition interface {
@@ -473,5 +474,71 @@ func (bc *BotCondition) IsMet(data *TriggeredRuleData, settings interface{}) (bo
 }
 
 func (bc *BotCondition) MergeDuplicates(data []interface{}) interface{} {
+	return data[0] // no point in having duplicates of this
+}
+
+/////////////////////////////////////////////////////////////////
+
+type MessageEditedData struct {
+	Treshold int
+}
+
+var _ Condition = (*MessageEditedCondition)(nil)
+
+type MessageEditedCondition struct {
+	NewMessage bool // if true, then blacklist mode, otherwise whitelist mode
+}
+
+func (mc *MessageEditedCondition) Kind() RulePartType {
+	return RulePartCondition
+}
+
+func (mc *MessageEditedCondition) DataType() interface{} {
+	return &MessageEditedData{}
+}
+
+func (mc *MessageEditedCondition) Name() string {
+	if mc.NewMessage {
+		return "New message"
+	}
+
+	return "Edited message"
+}
+
+func (mc *MessageEditedCondition) Description() string {
+	if mc.Below {
+		return "Ignore edited messages"
+	}
+
+	return "Only examine edited messages"
+}
+
+func (mc *MessageEditedCondition) UserSettings() []*SettingDef {
+	return []*SettingDef{}
+}
+
+func (mc *MessageEditedCondition) IsMet(data *TriggeredRuleData, settings interface{}) (bool, error) {
+	if data.Message == nil {
+		// pass the condition if no message is found
+		return true, nil
+	}
+	if data.Message.EditedTimestamp == "" {
+		// new post
+		if mc.NewMessage {
+			return true, nil
+		} else {
+			return false, nil
+		}
+	}
+
+	// account is older than threshold
+	if mc.NewMessage {
+		return false, nil
+	} else {
+		return true, nil
+	}
+}
+
+func (mc *MessageEditedCondition) MergeDuplicates(data []interface{}) interface{} {
 	return data[0] // no point in having duplicates of this
 }

--- a/automod/conditions.go
+++ b/automod/conditions.go
@@ -501,15 +501,13 @@ func (mc *MessageEditedCondition) Name() string {
 	if mc.NewMessage {
 		return "New message"
 	}
-
 	return "Edited message"
 }
 
 func (mc *MessageEditedCondition) Description() string {
-	if mc.Below {
+	if mc.NewMessage {
 		return "Ignore edited messages"
 	}
-
 	return "Only examine edited messages"
 }
 
@@ -526,17 +524,15 @@ func (mc *MessageEditedCondition) IsMet(data *TriggeredRuleData, settings interf
 		// new post
 		if mc.NewMessage {
 			return true, nil
-		} else {
-			return false, nil
 		}
+		return false, nil
 	}
 
 	// account is older than threshold
 	if mc.NewMessage {
 		return false, nil
-	} else {
-		return true, nil
 	}
+	return true, nil
 }
 
 func (mc *MessageEditedCondition) MergeDuplicates(data []interface{}) interface{} {

--- a/automod/rulepart.go
+++ b/automod/rulepart.go
@@ -57,6 +57,7 @@ var RulePartMap = map[int]RulePart{
 	211: &ChannelCategoriesCondition{Blacklist: true},
 	212: &ChannelCategoriesCondition{Blacklist: false},
 	213: &MessageEditedCondition{NewMessage: true},
+	214: &MessageEditedCondition{NewMessage: false},
 
 	// Effects 3xx
 	300: &DeleteMessageEffect{},

--- a/automod/rulepart.go
+++ b/automod/rulepart.go
@@ -56,6 +56,7 @@ var RulePartMap = map[int]RulePart{
 	210: &BotCondition{Ignore: false},
 	211: &ChannelCategoriesCondition{Blacklist: true},
 	212: &ChannelCategoriesCondition{Blacklist: false},
+	213: &MessageEditedCondition{NewMessage: true},
 
 	// Effects 3xx
 	300: &DeleteMessageEffect{},


### PR DESCRIPTION
I mocked up this change for a feature that would be useful on my server. I have not yet been able to run/test this code but I saw that my suggestion got pinned on the server and if this helps to get it implemented faster I hope I can save the dev team's time.

Hopefully it's on the right track and doesn't need too much change in order to be implemented/useful.