### PR TITLE
Adds targetHasRoleId and targetHasRoleName functions 

### DIFF
--- a/common/templates/context.go
+++ b/common/templates/context.go
@@ -229,6 +229,9 @@ func baseContextFuncs(c *Context) {
 	c.ContextFuncs["giveRoleName"] = c.tmplGiveRoleName
 	c.ContextFuncs["takeRoleID"] = c.tmplTakeRoleID
 	c.ContextFuncs["takeRoleName"] = c.tmplTakeRoleName
+	c.ContextFuncs["targetHasRoleID"] = c.tmplTargetHasRoleID
+	c.ContextFuncs["targetHasRoleName"] = c.tmplTargetHasRoleName
+
 
 	c.ContextFuncs["deleteResponse"] = c.tmplDelResponse
 	c.ContextFuncs["deleteTrigger"] = c.tmplDelTrigger

--- a/common/templates/context_funcs.go
+++ b/common/templates/context_funcs.go
@@ -251,7 +251,7 @@ func (c *Context) tmplTargetHasRoleID(target interface{}, roleID interface{}) bo
 		return false
 	}
 
-	ts := bot.GetMember(cs.Guild.ID, targetID)
+	ts := bot.GetMember(c.GS.ID, targetID)
 
 	role := ToInt64(roleID)
 	if role == 0 {
@@ -275,7 +275,7 @@ func (c *Context) tmplTargetHasRoleName(target interface{}, name string) bool {
 		return false
 	}
 
-	ts := bot.GetMember(cs.Guild.ID, targetID)
+	ts := bot.GetMember(c.GS.ID, targetID)
 	
 	c.GS.RLock()
 

--- a/common/templates/context_funcs.go
+++ b/common/templates/context_funcs.go
@@ -241,6 +241,62 @@ func targetUserID(input interface{}) int64 {
 	}
 }
 
+func (c *Context) tmplTargetHasRoleID(target interface{}, roleID interface{}) bool {
+	if c.IncreaseCheckCallCounter("has_role", 200) {
+		return false
+	}
+
+	targetID := targetUserID(target)
+	if targetID == 0 {
+		return false
+	}
+
+	ts := bot.GetMember(cs.Guild.ID, targetID)
+
+	role := ToInt64(roleID)
+	if role == 0 {
+		return false
+	}
+
+	c.GS.RLock()
+	contains := common.ContainsInt64Slice(ts.Roles, role)
+	c.GS.RUnlock()
+	return contains
+
+}
+
+func (c *Context) tmplTargetHasRoleName(target interface{}, name string) bool {
+	if c.IncreaseCheckCallCounter("has_role", 200) {
+		return false
+	}
+
+	targetID := targetUserID(target)
+	if targetID == 0 {
+		return false
+	}
+
+	ts := bot.GetMember(cs.Guild.ID, targetID)
+	
+	c.GS.RLock()
+
+	for _, r := range c.GS.Guild.Roles {
+		if strings.EqualFold(r.Name, name) {
+			if common.ContainsInt64Slice(ts.Roles, r.ID) {
+				c.GS.RUnlock()
+				return true
+			}
+
+			c.GS.RUnlock()
+			return false
+		}
+	}
+
+	c.GS.RUnlock()
+	return false
+
+}
+
+
 func (c *Context) tmplGiveRoleID(target interface{}, roleID interface{}) string {
 	if c.IncreaseCheckCallCounter("add_role", 10) {
 		return ""


### PR DESCRIPTION
This requests adds the functions targetHasRoleID and targetHasRoleName, allowing for custom commands that can check the role status of any user, not just the user who activated the command. At least, I hope!