### PR TITLE
Adds targetHasRoleId and targetHasRoleName functions

### DIFF
--- a/common/templates/context.go
+++ b/common/templates/context.go
@@ -229,6 +229,9 @@ func baseContextFuncs(c *Context) {
 	c.ContextFuncs["giveRoleName"] = c.tmplGiveRoleName
 	c.ContextFuncs["takeRoleID"] = c.tmplTakeRoleID
 	c.ContextFuncs["takeRoleName"] = c.tmplTakeRoleName
+	c.ContextFuncs["targetHasRoleID"] = c.tmplTargetHasRoleID
+	c.ContextFuncs["targetHasRoleName"] = c.tmplTargetHasRoleName
+
 
 	c.ContextFuncs["deleteResponse"] = c.tmplDelResponse
 	c.ContextFuncs["deleteTrigger"] = c.tmplDelTrigger

--- a/common/templates/context.go
+++ b/common/templates/context.go
@@ -229,9 +229,10 @@ func baseContextFuncs(c *Context) {
 	c.ContextFuncs["giveRoleName"] = c.tmplGiveRoleName
 	c.ContextFuncs["takeRoleID"] = c.tmplTakeRoleID
 	c.ContextFuncs["takeRoleName"] = c.tmplTakeRoleName
+	/*
 	c.ContextFuncs["targetHasRoleID"] = c.tmplTargetHasRoleID
 	c.ContextFuncs["targetHasRoleName"] = c.tmplTargetHasRoleName
-
+	*/
 
 	c.ContextFuncs["deleteResponse"] = c.tmplDelResponse
 	c.ContextFuncs["deleteTrigger"] = c.tmplDelTrigger

--- a/common/templates/context.go
+++ b/common/templates/context.go
@@ -229,10 +229,10 @@ func baseContextFuncs(c *Context) {
 	c.ContextFuncs["giveRoleName"] = c.tmplGiveRoleName
 	c.ContextFuncs["takeRoleID"] = c.tmplTakeRoleID
 	c.ContextFuncs["takeRoleName"] = c.tmplTakeRoleName
-	/*
+	
 	c.ContextFuncs["targetHasRoleID"] = c.tmplTargetHasRoleID
 	c.ContextFuncs["targetHasRoleName"] = c.tmplTargetHasRoleName
-	*/
+	
 
 	c.ContextFuncs["deleteResponse"] = c.tmplDelResponse
 	c.ContextFuncs["deleteTrigger"] = c.tmplDelTrigger

--- a/common/templates/context_funcs.go
+++ b/common/templates/context_funcs.go
@@ -251,7 +251,7 @@ func (c *Context) tmplTargetHasRoleID(target interface{}, roleID interface{}) bo
 		return false
 	}
 
-	ts := bot.GetMember(cs.Guild.ID, targetID)
+	ts := bot.GetMember(c.GS.ID, targetID)
 
 	role := ToInt64(roleID)
 	if role == 0 {
@@ -275,7 +275,7 @@ func (c *Context) tmplTargetHasRoleName(target interface{}, name string) bool {
 		return false
 	}
 
-	ts := bot.GetMember(cs.Guild.ID, targetID)
+	ts := bot.GetMember(c.GS.ID, targetID)
 	
 	c.GS.RLock()
 

--- a/common/templates/context_funcs.go
+++ b/common/templates/context_funcs.go
@@ -262,9 +262,9 @@ func (c *Context) tmplTargetHasRoleID(target interface{}, roleID interface{}) bo
 		return false
 	}
 
-	c.GS.RLock()
+	
 	contains := common.ContainsInt64Slice(ts.Roles, role)
-	c.GS.RUnlock()
+	
 	return contains
 
 }

--- a/common/templates/context_funcs.go
+++ b/common/templates/context_funcs.go
@@ -3,13 +3,14 @@ package templates
 import (
 	"errors"
 	"fmt"
-	"github.com/jonas747/discordgo"
-	"github.com/jonas747/yagpdb/bot"
-	"github.com/jonas747/yagpdb/common"
 	"reflect"
 	"strconv"
 	"strings"
 	"time"
+
+	"github.com/jonas747/discordgo"
+	"github.com/jonas747/yagpdb/bot"
+	"github.com/jonas747/yagpdb/common"
 )
 
 var ErrTooManyCalls = errors.New("Too many calls to this function")
@@ -241,6 +242,7 @@ func targetUserID(input interface{}) int64 {
 	}
 }
 
+/*
 func (c *Context) tmplTargetHasRoleID(target interface{}, roleID interface{}) bool {
 	if c.IncreaseCheckCallCounter("has_role", 200) {
 		return false
@@ -276,7 +278,7 @@ func (c *Context) tmplTargetHasRoleName(target interface{}, name string) bool {
 	}
 
 	ts := bot.GetMember(c.GS.ID, targetID)
-	
+
 	c.GS.RLock()
 
 	for _, r := range c.GS.Guild.Roles {
@@ -295,7 +297,7 @@ func (c *Context) tmplTargetHasRoleName(target interface{}, name string) bool {
 	return false
 
 }
-
+*/
 
 func (c *Context) tmplGiveRoleID(target interface{}, roleID interface{}) string {
 	if c.IncreaseCheckCallCounter("add_role", 10) {

--- a/common/templates/context_funcs.go
+++ b/common/templates/context_funcs.go
@@ -241,6 +241,62 @@ func targetUserID(input interface{}) int64 {
 	}
 }
 
+func (c *Context) tmplTargetHasRoleID(target interface{}, roleID interface{}) bool {
+	if c.IncreaseCheckCallCounter("has_role", 200) {
+		return false
+	}
+
+	targetID := targetUserID(target)
+	if targetID == 0 {
+		return false
+	}
+
+	ts := bot.GetMember(cs.Guild.ID, targetID)
+
+	role := ToInt64(roleID)
+	if role == 0 {
+		return false
+	}
+
+	c.GS.RLock()
+	contains := common.ContainsInt64Slice(ts.Roles, role)
+	c.GS.RUnlock()
+	return contains
+
+}
+
+func (c *Context) tmplTargetHasRoleName(target interface{}, name string) bool {
+	if c.IncreaseCheckCallCounter("has_role", 200) {
+		return false
+	}
+
+	targetID := targetUserID(target)
+	if targetID == 0 {
+		return false
+	}
+
+	ts := bot.GetMember(cs.Guild.ID, targetID)
+	
+	c.GS.RLock()
+
+	for _, r := range c.GS.Guild.Roles {
+		if strings.EqualFold(r.Name, name) {
+			if common.ContainsInt64Slice(ts.Roles, r.ID) {
+				c.GS.RUnlock()
+				return true
+			}
+
+			c.GS.RUnlock()
+			return false
+		}
+	}
+
+	c.GS.RUnlock()
+	return false
+
+}
+
+
 func (c *Context) tmplGiveRoleID(target interface{}, roleID interface{}) string {
 	if c.IncreaseCheckCallCounter("add_role", 10) {
 		return ""

--- a/common/templates/context_funcs.go
+++ b/common/templates/context_funcs.go
@@ -242,7 +242,6 @@ func targetUserID(input interface{}) int64 {
 	}
 }
 
-/*
 func (c *Context) tmplTargetHasRoleID(target interface{}, roleID interface{}) bool {
 	if c.IncreaseCheckCallCounter("has_role", 200) {
 		return false
@@ -253,7 +252,10 @@ func (c *Context) tmplTargetHasRoleID(target interface{}, roleID interface{}) bo
 		return false
 	}
 
-	ts := bot.GetMember(c.GS.ID, targetID)
+	ts, err := bot.GetMember(c.GS.ID, targetID)
+	if err != nil {
+		return false
+	}
 
 	role := ToInt64(roleID)
 	if role == 0 {
@@ -277,7 +279,10 @@ func (c *Context) tmplTargetHasRoleName(target interface{}, name string) bool {
 		return false
 	}
 
-	ts := bot.GetMember(c.GS.ID, targetID)
+	ts, err := bot.GetMember(c.GS.ID, targetID)
+	if err != nil {
+		return false
+	}
 
 	c.GS.RLock()
 
@@ -297,7 +302,6 @@ func (c *Context) tmplTargetHasRoleName(target interface{}, name string) bool {
 	return false
 
 }
-*/
 
 func (c *Context) tmplGiveRoleID(target interface{}, roleID interface{}) string {
 	if c.IncreaseCheckCallCounter("add_role", 10) {


### PR DESCRIPTION
This request adds the functions targetHasRoleID and targetHasRoleName, allowing for custom commands that can check any user's role information, rather than being specific to the user who called the command.