### PR TITLE
ID to Message ID

### DIFF
--- a/moderation/commands.go
+++ b/moderation/commands.go
@@ -400,7 +400,7 @@ var ModerationCommands = []*commands.YAGCommand{
 		Description:   "Add/Edit a modlog reason",
 		RequiredArgs:  2,
 		Arguments: []*dcmd.ArgDef{
-			&dcmd.ArgDef{Name: "ID", Type: dcmd.Int},
+			&dcmd.ArgDef{Name: "Message ID", Type: dcmd.Int},
 			&dcmd.ArgDef{Name: "Reason", Type: dcmd.String},
 		},
 		RunFunc: func(parsed *dcmd.Data) (interface{}, error) {


### PR DESCRIPTION
This help clarification confuses people, they think ID is from warning's ID not modlog's messageID.