### PR TITLE
Change prefix to Command Prefix

### DIFF
--- a/commands/assets/commands.html
+++ b/commands/assets/commands.html
@@ -29,8 +29,8 @@
                             <div class="row">
                                 <div class="col-lg-6">
                                     <div class="form-group">
-                                        <label for="prefix">Prefix</label>
-                                        <input type="text" class="form-control" id="prefix" name="Prefix" value="{{.CommandPrefix}}">
+                                        <label for="prefix">Command Prefix</label>
+                                        <input type="text" class="form-control" id="prefix" name="Prefix (Type before all commands)" value="{{.CommandPrefix}}">
                                     </div>
                                 </div>
                                 <div class="col-lg-6">


### PR DESCRIPTION
This is just a one word on the cmd settings page as it might help with some of the silly things people type

Also changed the value of the text field if empty to Prefix (type before all commands)