### PR TITLE
usability suggestion for control_panel combined overview

### DIFF
--- a/rolecommands/web.go
+++ b/rolecommands/web.go
@@ -420,6 +420,7 @@ func (p *Plugin) LoadServerHomeWidget(w http.ResponseWriter, r *http.Request) (w
 	templateData["SettingsPath"] = "/rolecommands/"
 
 	numCommands, err := models.RoleCommands(qm.Where("guild_id = ?", g.ID)).CountG(r.Context())
+	numGroups, err := models.RoleGroups(qm.Where("guild_id = ?", g.ID)).CountG(r.Context())
 
 	if numCommands > 0 {
 		templateData["WidgetEnabled"] = true
@@ -427,7 +428,10 @@ func (p *Plugin) LoadServerHomeWidget(w http.ResponseWriter, r *http.Request) (w
 		templateData["WidgetDisabled"] = true
 	}
 
-	templateData["WidgetBody"] = template.HTML(fmt.Sprintf("Active RoleCommands: <code>%d</code>", numCommands))
+	templateData["WidgetBody"] = template.HTML(fmt.Sprintf(`<ul>
+		<li>Active RoleCommands: <code>%d</code></li>
+		<li>Active RoleGroups: <code>%d</code></li>
+		</ul>`, numCommands, numGroups))
 
 	return templateData, err
 }

--- a/rolecommands/web.go
+++ b/rolecommands/web.go
@@ -420,6 +420,7 @@ func (p *Plugin) LoadServerHomeWidget(w http.ResponseWriter, r *http.Request) (w
 	templateData["SettingsPath"] = "/rolecommands/"
 
 	numCommands, err := models.RoleCommands(qm.Where("guild_id = ?", g.ID)).CountG(r.Context())
+	
 	if err != nil{
 		return templateData, err
     	}

--- a/rolecommands/web.go
+++ b/rolecommands/web.go
@@ -420,6 +420,10 @@ func (p *Plugin) LoadServerHomeWidget(w http.ResponseWriter, r *http.Request) (w
 	templateData["SettingsPath"] = "/rolecommands/"
 
 	numCommands, err := models.RoleCommands(qm.Where("guild_id = ?", g.ID)).CountG(r.Context())
+	if err != nil{
+		return templateData, err
+    	}
+	
 	numGroups, err := models.RoleGroups(qm.Where("guild_id = ?", g.ID)).CountG(r.Context())
 
 	if numCommands > 0 {


### PR DESCRIPTION
Rolecommands plugin has two limits, rolecommands and rolegroups count, they both are capped, It would be more informative to present both of these counts. Dunno whether on not to manually write that current max 1000 there or not,