### PR TITLE
Update string to reduce confusion

### DIFF
--- a/moderation/commands.go
+++ b/moderation/commands.go
@@ -34,7 +34,7 @@ func MBaseCmd(cmdData *dcmd.Data, targetID int64) (config *Config, targetUser *d
 			gs.RUnlock()
 
 			if !above {
-				return config, targetMember.DGoUser(), commands.NewPublicError("Can't use moderation commands on users ranked higher than you")
+				return config, targetMember.DGoUser(), commands.NewPublicError("Can't use moderation commands on users ranked the same or higher than you")
 			}
 
 			return config, targetMember.DGoUser(), nil


### PR DESCRIPTION
You cant use mod commands on users ranked the same or higher than you, changed the message to be accurate instead of saying "higher" it now says "the same as or higher"