### PR TITLE
Rsvp help emoji

### DIFF
--- a/rsvp/plugin_bot.go
+++ b/rsvp/plugin_bot.go
@@ -36,7 +36,7 @@ func (p *Plugin) AddCommands() {
 	catEvents := &dcmd.Category{
 		Name:        "Events",
 		Description: "Event commands",
-		HelpEmoji:   "🎫",
+		HelpEmoji:   "🎟",
 		EmbedColor:  0x42b9f4,
 	}
 	container := commands.CommandSystem.Root.Sub("events", "event")


### PR DESCRIPTION
Changed to 🎟 from 🎫 as its not used like the other ticket and its an "admit one" ticket for ios