### PR TITLE
uint8 added

### DIFF
--- a/common/templates/general.go
+++ b/common/templates/general.go
@@ -412,6 +412,8 @@ func tmplToInt(from interface{}) int {
 		return int(t)
 	case uint:
 		return int(t)
+	case uint8:
+		return int(t)
 	case uint32:
 		return int(t)
 	case uint64:


### PR DESCRIPTION
This type case was missing and actually necessary, because indexing a string creates uint8.