### PR TITLE
Docker: Pin Postgres major version

### DIFF
--- a/yagpdb_docker/docker-compose.dev.yml
+++ b/yagpdb_docker/docker-compose.dev.yml
@@ -37,7 +37,7 @@ services:
       - redis:/data
 
   db:
-    image: postgres
+    image: postgres:11
     restart: unless-stopped
     volumes:
       - db:/var/lib/postgresql/data

--- a/yagpdb_docker/docker-compose.yml
+++ b/yagpdb_docker/docker-compose.yml
@@ -37,7 +37,7 @@ services:
       - redis:/data
 
   db:
-    image: postgres
+    image: postgres:11
     restart: unless-stopped
     volumes:
       - db:/var/lib/postgresql/data


### PR DESCRIPTION
The only method to migrate data between major Postgres vesrions is a backup and
restore. This provides no clean path for users to rebuild their server so let's
pin the version to reduce surprises.

Although version 10 was current when this config was originally checked in,
version 11 has been the latest for 9 months and I am assuming more users are
using that "latest".

With version 12 coming out soon, it seems like a good time to resolve this
problem

For users discovering this commit message that wish to upgrade, the following
gist can be useful:
https://gist.github.com/LoganK/7ceb1506102f5d469556c69620a3d1c2

(Remember to change your volume name in your docker-compose file.)