### PR TITLE
toTime function for templates (name changed newDate)

### DIFF
--- a/common/templates/context.go
+++ b/common/templates/context.go
@@ -65,7 +65,7 @@ var (
 		"shuffle":     shuffle,
 		"seq":         sequence,
 		"currentTime": tmplCurrentTime,
-		"toTime":      tmplDateToTime,
+		"newDate":     tmplNewDate,
 
 		"escapeHere":         tmplEscapeHere,
 		"escapeEveryone":     tmplEscapeEveryone,

--- a/common/templates/context.go
+++ b/common/templates/context.go
@@ -65,6 +65,7 @@ var (
 		"shuffle":     shuffle,
 		"seq":         sequence,
 		"currentTime": tmplCurrentTime,
+		"toTime":      tmplDateToTime,
 
 		"escapeHere":         tmplEscapeHere,
 		"escapeEveryone":     tmplEscapeEveryone,

--- a/common/templates/general.go
+++ b/common/templates/general.go
@@ -656,7 +656,7 @@ func tmplCurrentTime() time.Time {
 	return time.Now()
 }
 
-func tmplDateToTime(year, monthInt, day, hour, min, sec int) time.Time {
+func tmplNewDate(year, monthInt, day, hour, min, sec int) time.Time {
 	var month time.Month
 	month = time.Month(monthInt)
 	return time.Date(year, month, day, hour, min, sec, 0, time.UTC)

--- a/common/templates/general.go
+++ b/common/templates/general.go
@@ -656,6 +656,10 @@ func tmplCurrentTime() time.Time {
 	return time.Now()
 }
 
+func tmplDateToTime(year int, month time.Month, day, hour, min, sec int) time.Time {
+	return time.Date(year, month, day, hour, min, sec, 0, time.UTC)
+}
+
 func tmplEscapeHere(in string) string {
 	return common.EscapeEveryoneHere(in, false, true)
 }

--- a/common/templates/general.go
+++ b/common/templates/general.go
@@ -656,7 +656,9 @@ func tmplCurrentTime() time.Time {
 	return time.Now()
 }
 
-func tmplDateToTime(year int, month time.Month, day, hour, min, sec int) time.Time {
+func tmplDateToTime(year, monthInt, day, hour, min, sec int) time.Time {
+	var month time.Month
+	month = time.Month(monthInt)
 	return time.Date(year, month, day, hour, min, sec, 0, time.UTC)
 }
 


### PR DESCRIPTION
This was discussed today in # custom-command-discussion channel, albeit it's doable without specific function, maybe this one is simpler for users. I omitted nanoseconds and also *Location - left it as UTC.