### PR TITLE
slight changes in presenting custom commands

### DIFF
--- a/customcommands/assets/customcommands.html
+++ b/customcommands/assets/customcommands.html
@@ -260,7 +260,7 @@
                 <h2 class="card-title">
 
                     <a data-toggle="collapse" data-parent="#accordion" href="#collapse_cmd{{.LocalID}}" aria-expanded="false" aria-controls="collapse_cmd{{.LocalID}}">
-                        #{{.LocalID}} - {{index $dot.CCTriggerTypes .TriggerType}} {{if and (ne .TriggerType 5) (ne .TriggerType 6)}}: <span class="ccTextTriggerSpan">{{.TextTrigger}}</span>{{else if ne .TriggerType 6}}Every {{call $dot.GetCCInterval .}} {{if eq (call $dot.GetCCIntervalType .) 1}}hour(s){{else}}minute(s){{end}}{{end}}
+                        #{{.LocalID}} - {{index $dot.CCTriggerTypes .TriggerType}} {{if and (ne .TriggerType 5) (ne .TriggerType 6)}}: <span class="cc-text-trigger-span">{{.TextTrigger}}</span>{{else if ne .TriggerType 6}}Every {{call $dot.GetCCInterval .}} {{if eq (call $dot.GetCCIntervalType .) 1}}hour(s){{else}}minute(s){{end}}{{end}}
                     </a>
                 </h2>
             </div>

--- a/customcommands/assets/customcommands.html
+++ b/customcommands/assets/customcommands.html
@@ -260,7 +260,7 @@
                 <h2 class="card-title">
 
                     <a data-toggle="collapse" data-parent="#accordion" href="#collapse_cmd{{.LocalID}}" aria-expanded="false" aria-controls="collapse_cmd{{.LocalID}}">
-                        #{{.LocalID}} - {{index $dot.CCTriggerTypes .TriggerType}} {{if and (ne .TriggerType 5) (ne .TriggerType 6)}}{{.TextTrigger}}{{else if ne .TriggerType 6}}Every {{call $dot.GetCCInterval .}} {{if eq (call $dot.GetCCIntervalType .) 1}}hour(s){{else}}minute(s){{end}}{{end}}
+                        #{{.LocalID}} - {{index $dot.CCTriggerTypes .TriggerType}} {{if and (ne .TriggerType 5) (ne .TriggerType 6)}}: <span class="ccTextTriggerSpan">{{.TextTrigger}}</span>{{else if ne .TriggerType 6}}Every {{call $dot.GetCCInterval .}} {{if eq (call $dot.GetCCIntervalType .) 1}}hour(s){{else}}minute(s){{end}}{{end}}
                     </a>
                 </h2>
             </div>


### PR DESCRIPTION
the colon between .TriggerType and .TextTrigger already helps to separate default text better and increases readability. 
I added <span> for users who want to alter CSS styling further on their side - I know it deviates from bootstrap styling, but that <span> does not kill anything : )