### PR TITLE
Function to delete all message reactions

### DIFF
--- a/common/templates/context.go
+++ b/common/templates/context.go
@@ -376,6 +376,7 @@ func baseContextFuncs(c *Context) {
 	c.ContextFuncs["deleteResponse"] = c.tmplDelResponse
 	c.ContextFuncs["deleteTrigger"] = c.tmplDelTrigger
 	c.ContextFuncs["deleteMessage"] = c.tmplDelMessage
+	c.ContextFuncs["deleteAllMessageReactions"] = c.tmplDelAllMessageReactions
 	c.ContextFuncs["getMessage"] = c.tmplGetMessage
 	c.ContextFuncs["getMember"] = c.tmplGetMember
 	c.ContextFuncs["addReactions"] = c.tmplAddReactions

--- a/common/templates/context_funcs.go
+++ b/common/templates/context_funcs.go
@@ -598,6 +598,19 @@ func (c *Context) tmplDelMessage(channel, msgID interface{}, args ...interface{}
 	return ""
 }
 
+func (c *Context) tmplDelAllMessageReactions(channel, msgID interface{}) string {
+	cID := c.ChannelArg(channel)
+	if cID == 0 {
+		return ""
+	}
+
+	mID := ToInt64(msgID)
+
+	common.BotSession.MessageReactionsRemoveAll(cID, mID)
+
+	return ""
+}
+
 func (c *Context) tmplGetMessage(channel, msgID interface{}) (*discordgo.Message, error) {
 	if c.IncreaseCheckGenericAPICall() {
 		return nil, ErrTooManyAPICalls

--- a/common/templates/context_funcs.go
+++ b/common/templates/context_funcs.go
@@ -598,17 +598,21 @@ func (c *Context) tmplDelMessage(channel, msgID interface{}, args ...interface{}
 	return ""
 }
 
-func (c *Context) tmplDelAllMessageReactions(channel, msgID interface{}) string {
+func (c *Context) tmplDelAllMessageReactions(channel, msgID interface{}) (string, error) {
+	if c.IncreaseCheckGenericAPICall() {
+		return "", ErrTooManyAPICalls
+	}
+
 	cID := c.ChannelArg(channel)
 	if cID == 0 {
-		return ""
+		return "", nil
 	}
 
 	mID := ToInt64(msgID)
 
 	common.BotSession.MessageReactionsRemoveAll(cID, mID)
 
-	return ""
+	return "", nil
 }
 
 func (c *Context) tmplGetMessage(channel, msgID interface{}) (*discordgo.Message, error) {


### PR DESCRIPTION
users have mentioned the need for this, it's blunt force removal - not specific to reactionName or userID, but maybe necessary