### PR TITLE
cc: append item to slice with size limit

### DIFF
--- a/customcommands/tmplextensions.go
+++ b/customcommands/tmplextensions.go
@@ -331,7 +331,7 @@ func appendWithLimit(ctx *templates.Context) func(slice []interface{}, values ..
 		if isPremium, _ := premium.IsGuildPremium(ctx.GS.ID); isPremium {
 			limitMuliplier = 10
 		}
-		if len(slice)+len(values) < limitMuliplier*50 {
+		if len(slice)+len(values) < limitMuliplier*1000 {
 			return append(slice, values...), nil
 		}
 		return nil, errors.New("resulting slice exceeds size limit")


### PR DESCRIPTION
Adds a template function to add an item to a slice, with size limit to prevent abuse.
The size limit uses the same logic as database entries, so that the user can retrieve database entries iteratively.