### PR TITLE
trigger name - whitespace before colon update

### DIFF
--- a/customcommands/assets/customcommands.html
+++ b/customcommands/assets/customcommands.html
@@ -260,7 +260,7 @@
                 <h2 class="card-title">
 
                     <a data-toggle="collapse" data-parent="#accordion" href="#collapse_cmd{{.LocalID}}" aria-expanded="false" aria-controls="collapse_cmd{{.LocalID}}">
-                        #{{.LocalID}} - {{index $dot.CCTriggerTypes .TriggerType}} {{if and (ne .TriggerType 5) (ne .TriggerType 6)}}: <span class="cc-text-trigger-span">{{.TextTrigger}}</span>{{else if ne .TriggerType 6}}Every {{call $dot.GetCCInterval .}} {{if eq (call $dot.GetCCIntervalType .) 1}}hour(s){{else}}minute(s){{end}}{{end}}
+                        #{{.LocalID}} - {{index $dot.CCTriggerTypes .TriggerType}}{{if and (ne .TriggerType 5) (ne .TriggerType 6)}}: <span class="cc-text-trigger-span">{{.TextTrigger}}</span>{{else if ne .TriggerType 6}}: Every {{call $dot.GetCCInterval .}} {{if eq (call $dot.GetCCIntervalType .) 1}}hour(s){{else}}minute(s){{end}}{{end}}
                     </a>
                 </h2>
             </div>


### PR DESCRIPTION
was wondering why I left the  white-space there in front of colon for regular command names... because of Inteval trigger! But this solution might be better > Interval: Every... and IntervalEvery is prevented : )