### PR TITLE
Add Discord status alerts to dashboard

### DIFF
--- a/cmd/yagpdb/templates/cp_main.html
+++ b/cmd/yagpdb/templates/cp_main.html
@@ -142,7 +142,14 @@
 {{define "cp_alerts"}}
 <script>
 $(function(){
-    showAlerts("{{json .Alerts}}")
+    showAlerts("{{json .Alerts}}");
+    $.getJSON("https://srhpyqt94yxb.statuspage.io/api/v2/incidents/unresolved.json", function(data) {
+        if (data.incidents) {
+            data.incidents.forEach(function(incident) {
+                addAlert("warning", "Discord's " + incident.status + " an incident: " + incident.name + ". Functionality may be limited.");
+            })
+        }
+    });
 })
 </script>
 <div id="alerts">


### PR DESCRIPTION
Notifies users of potential problems with Discord servers to assist in troubleshooting issues with the bot.