### PR TITLE
Add ttc as alias for toggletimeconversion

### DIFF
--- a/timezonecompanion/plugin_bot.go
+++ b/timezonecompanion/plugin_bot.go
@@ -121,7 +121,7 @@ func (p *Plugin) AddCommands() {
 	}, &commands.YAGCommand{
 		CmdCategory:         commands.CategoryTool,
 		Name:                "ToggleTimeConversion",
-		Aliases:             []string{"toggletconv"},
+		Aliases:             []string{"toggletconv", "ttc"},
 		Description:         "Toggles automatic time conversion for people with registered timezones (setz) in this channel, its on by default, toggle all channels by giving it `all`",
 		RequireDiscordPerms: []int64{discordgo.PermissionManageMessages, discordgo.PermissionManageServer},
 		Arguments: []*dcmd.ArgDef{


### PR DESCRIPTION
Self explanatory, all the aliases for toggletimeconversion are pretty long, it would be nice if there were a shorter alias such as ttc.