### PR TITLE
Satty9361 edit nickname template

### DIFF
--- a/common/templates/context.go
+++ b/common/templates/context.go
@@ -396,6 +396,7 @@ func baseContextFuncs(c *Context) {
 	c.ContextFuncs["editChannelName"] = c.tmplEditChannelName
 	c.ContextFuncs["onlineCount"] = c.tmplOnlineCount
 	c.ContextFuncs["onlineCountBots"] = c.tmplOnlineCountBots
+	c.ContextFuncs["editNickname"] =c.tmplEditNickname
 }
 
 type limitedWriter struct {

--- a/common/templates/context_funcs.go
+++ b/common/templates/context_funcs.go
@@ -877,20 +877,14 @@ func (c *Context) tmplEditNickname(Nickname string) (string, error) {
 		if c.MS == nil {
 		return "", nil
 	}
-
-	c.GS.RLock()
-	gID := c.GS.ID
-	memberNick := c.MS.Nick
-	memberID := c.MS.ID
-	c.GS.RUnlock()
 	
-	if strings.Compare(memberNick, Nickname) == 0 {
+	if strings.Compare(c.MS.Nick, Nickname) == 0 {
 	
 		return "", nil
 	
 	}
 	
-	err := common.BotSession.GuildMemberNickname(gID, memberID, Nickname)
+	err := common.BotSession.GuildMemberNickname(c.GS.ID, c.MS.ID, Nickname)
 	if err != nil {
 		return "", err
 	}

--- a/common/templates/context_funcs.go
+++ b/common/templates/context_funcs.go
@@ -868,3 +868,32 @@ func (c *Context) tmplOnlineCountBots() (int, error) {
 	return botCount, nil
 }
 
+func (c *Context) tmplEditNickname(Nickname string) (string, error) {
+
+	if c.IncreaseCheckCallCounter("edit_nick", 2) {
+		return "", ErrTooManyCalls
+	}
+
+		if c.MS == nil {
+		return "", nil
+	}
+
+	c.GS.RLock()
+	gID := c.GS.ID
+	memberNick := c.MS.Nick
+	memberID := c.MS.ID
+	c.GS.RUnlock()
+	
+	if strings.Compare(memberNick, Nickname) == 0 {
+	
+		return "", nil
+	
+	}
+	
+	err := common.BotSession.GuildMemberNickname(gID, memberID, Nickname)
+	if err != nil {
+		return "", err
+	}
+
+	return "", nil
+}


### PR DESCRIPTION
Added a new template to allow editing nickname of the user triggering a command. Editing nicknames are a very popular request however ability to edit nickname of any target user has misuse potential . Hence , implemented it to only work on triggering user similar to sendDM. 

Introduced a new checker "edit_nick" which allows only two calls per cc instance similar to tmplEditChannelName . 

Also, tried to save unnecessary API call if present nickname is already same as new nickname.