### PR TITLE
Small update to not send blank DMs when response only consists of whitespace for Punishments.

### DIFF
--- a/moderation/punishments.go
+++ b/moderation/punishments.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"strconv"
 	"time"
+	"strings"
 
 	"emperror.dev/errors"
 	"github.com/jinzhu/gorm"
@@ -160,7 +161,9 @@ func sendPunishDM(config *Config, dmMsg string, action ModlogAction, gs *dstate.
 		executed = "Failed executing template."
 	}
 
-	go bot.SendDM(member.ID, "**"+bot.GuildName(gs.ID)+":** "+executed)
+	if strings.TrimSpace(executed) != "" {
+		go bot.SendDM(member.ID, "**"+bot.GuildName(gs.ID)+":** "+executed)
+	}
 }
 
 func KickUser(config *Config, guildID, channelID int64, author *discordgo.User, reason string, user *discordgo.User) error {


### PR DESCRIPTION
Dont send DM if response only consists of whitespace. This can also be used to smartly disable ban/mute/unmute/kick/warn DMs while still allowing to do any kind of processing like maintaining Records in database upon Mod Action that the user wants to do.