### PR TITLE
slight bugfix in ServerStatsMemberPeriods query

### DIFF
--- a/serverstats/serverstats.go
+++ b/serverstats/serverstats.go
@@ -96,7 +96,10 @@ func RetrieveDailyStats(guildID int64) (*DailyStats, error) {
 	t := RoundHour(time.Now())
 	memberStatsRows, err := models.ServerStatsMemberPeriods(
 		models.ServerStatsMemberPeriodWhere.GuildID.EQ(guildID),
-		qm.Where("started > ?", time.Now().Add(time.Hour*-25))).AllG(context.Background())
+		qm.Where("created_at > ?", time.Now().Add(time.Hour*-25))).AllG(context.Background())
+	if err != nil {
+		return nil, err
+	}
 
 	// Sum the stats
 	for i, v := range memberStatsRows {


### PR DESCRIPTION
currently database table server_stats_member_periods does not have column "started", changed it to created_at and added also err check. Stats command for bot and also web page shows joined/left users, memberCount now.