### PR TITLE
getChannel template

### DIFF
--- a/common/templates/context.go
+++ b/common/templates/context.go
@@ -381,6 +381,7 @@ func baseContextFuncs(c *Context) {
 	c.ContextFuncs["deleteAllMessageReactions"] = c.tmplDelAllMessageReactions
 	c.ContextFuncs["getMessage"] = c.tmplGetMessage
 	c.ContextFuncs["getMember"] = c.tmplGetMember
+	c.ContextFuncs["getChannel"] = c.tmplGetChannel
 	c.ContextFuncs["addReactions"] = c.tmplAddReactions
 	c.ContextFuncs["addResponseReactions"] = c.tmplAddResponseReactions
 	c.ContextFuncs["addMessageReactions"] = c.tmplAddMessageReactions

--- a/common/templates/context_funcs.go
+++ b/common/templates/context_funcs.go
@@ -646,6 +646,27 @@ func (c *Context) tmplGetMember(id interface{}) (*discordgo.Member, error) {
 	return member.DGoCopy(), nil
 }
 
+func (c *Context) tmplGetChannel ( channel interface {}) (*dstate.ChannelState, error) {
+	
+	if c.IncreaseCheckGenericAPICall() {
+		return nil, ErrTooManyAPICalls
+	}
+
+	cID := c.ChannelArg(channel)
+	if cID == 0 {
+                return nil, nil //dont send an error , a nil output would indicate invalid/unknown channel
+        }
+
+	cstate := c.GS.ChannelCopy(true, cID)
+
+	if cstate == nil {
+		return nil, errors.New("Channel not in state")
+	}
+	
+	return cstate, nil
+
+}
+
 func (c *Context) tmplAddReactions(values ...reflect.Value) (reflect.Value, error) {
 	f := func(args []reflect.Value) (reflect.Value, error) {
 		if c.Msg == nil {


### PR DESCRIPTION
Users have requested for this. It is already possible with execCC with channelID followed by .Channel, this makes the process less convoluted. 

The lock argument in ChannelCopy should probably be false ? ( since ChannelArg already has a Rlock) however tmplRunCC has lock set to true hence i have kept it as true for now.