### PR TITLE
exec/execAdmin with execCC fix

### DIFF
--- a/commands/tmplexec.go
+++ b/commands/tmplexec.go
@@ -83,7 +83,7 @@ func TmplExecCmdFuncs(ctx *templates.Context, maxExec int, dryRun bool) (userCtx
 				messageCopy.ChannelID = ctx.CS.ID
 			}
 		}
-		mc := &discordgo.MessageCreate{ctx.Msg}
+		mc := &discordgo.MessageCreate{&messageCopy}
 		if maxExec < 1 {
 			return "", errors.New("Max number of commands executed in custom command")
 		}

--- a/commands/tmplexec.go
+++ b/commands/tmplexec.go
@@ -77,6 +77,12 @@ type cmdExecFunc func(cmd string, args ...interface{}) (interface{}, error)
 // Returns 2 functions to execute commands in user or bot context with limited about of commands executed
 func TmplExecCmdFuncs(ctx *templates.Context, maxExec int, dryRun bool) (userCtxCommandExec cmdExecFunc, botCtxCommandExec cmdExecFunc) {
 	execUser := func(cmd string, args ...interface{}) (interface{}, error) {
+		messageCopy := *ctx.Msg
+		if ctx.Msg.ChannelID != ctx.Msg.GuildID { //punishment dms shouldnt be able to execCC followed by exec/execAdmin to prevent loops
+			if ctx.CS != nil { //Check if CS is not a nil pointer 
+				messageCopy.ChannelID = ctx.CS.ID
+			}
+		}
 		mc := &discordgo.MessageCreate{ctx.Msg}
 		if maxExec < 1 {
 			return "", errors.New("Max number of commands executed in custom command")
@@ -92,6 +98,11 @@ func TmplExecCmdFuncs(ctx *templates.Context, maxExec int, dryRun bool) (userCtx
 
 		messageCopy := *ctx.Msg
 		messageCopy.Author = &botUserCopy
+		if ctx.Msg.ChannelID != ctx.Msg.GuildID { //punishment dms shouldnt be able to execCC followed by exec/execAdmin to prevent loops
+			if ctx.CS != nil { //Check if CS is not a nil pointer 
+				messageCopy.ChannelID = ctx.CS.ID
+			}
+		}
 
 		mc := &discordgo.MessageCreate{&messageCopy}
 		if maxExec < 1 {

--- a/commands/tmplexec.go
+++ b/commands/tmplexec.go
@@ -78,10 +78,8 @@ type cmdExecFunc func(cmd string, args ...interface{}) (interface{}, error)
 func TmplExecCmdFuncs(ctx *templates.Context, maxExec int, dryRun bool) (userCtxCommandExec cmdExecFunc, botCtxCommandExec cmdExecFunc) {
 	execUser := func(cmd string, args ...interface{}) (interface{}, error) {
 		messageCopy := *ctx.Msg
-		if ctx.Msg.ChannelID != ctx.Msg.GuildID { //punishment dms shouldnt be able to execCC followed by exec/execAdmin to prevent loops
-			if ctx.CS != nil { //Check if CS is not a nil pointer 
-				messageCopy.ChannelID = ctx.CS.ID
-			}
+		if ctx.CS != nil { //Check if CS is not a nil pointer 
+			messageCopy.ChannelID = ctx.CS.ID
 		}
 		mc := &discordgo.MessageCreate{&messageCopy}
 		if maxExec < 1 {
@@ -98,10 +96,8 @@ func TmplExecCmdFuncs(ctx *templates.Context, maxExec int, dryRun bool) (userCtx
 
 		messageCopy := *ctx.Msg
 		messageCopy.Author = &botUserCopy
-		if ctx.Msg.ChannelID != ctx.Msg.GuildID { //punishment dms shouldnt be able to execCC followed by exec/execAdmin to prevent loops
-			if ctx.CS != nil { //Check if CS is not a nil pointer 
-				messageCopy.ChannelID = ctx.CS.ID
-			}
+		if ctx.CS != nil { //Check if CS is not a nil pointer 
+			messageCopy.ChannelID = ctx.CS.ID
 		}
 
 		mc := &discordgo.MessageCreate{&messageCopy}


### PR DESCRIPTION
made these changes so that an exec/execAdmin following an execCC runs in the new channel. 

Have not incorporated channel update for dm templates ( eg: punishment dm templates) to prevent loops (eg: warn -> warn dm execCC -> execAdmin warn ...) . 
