### PR TITLE
Pagination Error , typo & other fixes/additions

### DIFF
--- a/automod/commands.go
+++ b/automod/commands.go
@@ -191,7 +191,7 @@ func (p *Plugin) AddCommands() {
 			}
 
 			for name, count := range violations {
-				out += fmt.Sprintf("Violation: %-20s count: %d\n", name, count)
+				out += fmt.Sprintf("Violation: %-20s Count: %d\n", name, count)
 			}
 
 			if out == "" {

--- a/automod/commands.go
+++ b/automod/commands.go
@@ -198,7 +198,7 @@ func (p *Plugin) AddCommands() {
 				return "No Violations found with specified conditions", nil
 			}
 
-			out = "```" + out + "```"
+			out = "```" + out + fmt.Sprintf("%-31s Count: %d\n", "Total", len(listViolations)) + "```"
 			return &discordgo.MessageEmbed{
 				Title:       "Violations Summary",
 				Description: out,
@@ -210,7 +210,7 @@ func (p *Plugin) AddCommands() {
 		CustomEnabled: true,
 		CmdCategory:   commands.CategoryModeration,
 		Name:          "ListViolations",
-		Description:   "Lists Violations of specified user /n old flag posts oldest violations in first page ( from oldest to newest ).",
+		Description:   "Lists Violations of specified user \n old flag posts oldest violations in first page ( from oldest to newest ).",
 		Aliases:       []string{"Violations", "ViolationLogs", "VLogs", "VLog"},
 		RequiredArgs:  1,
 		Arguments: []*dcmd.ArgDef{
@@ -238,7 +238,7 @@ func (p *Plugin) AddCommands() {
 				return nil, err
 			}
 
-			if len(listViolations) < 1 && page > 1 {
+			if len(listViolations) < 1 && p.LastResponse != nil { //Dont send No Results error on first execution
 				return nil, paginatedmessages.ErrNoResults
 			}
 

--- a/bot/paginatedmessages/pageinatedmessage.go
+++ b/bot/paginatedmessages/pageinatedmessage.go
@@ -174,7 +174,9 @@ func (p *PaginatedMessage) HandleReactionAdd(ra *discordgo.MessageReactionAdd) {
 	newMsg, err := p.Navigate(p, newPage)
 	if err != nil {
 		if err == ErrNoResults {
-			newPage--
+			if pageMod == 1 {
+				newPage--
+			}
 			if newPage < 1 {
 				newPage = 1
 			}


### PR DESCRIPTION
Pagination Error Patch : When specifying a page number in paginated messages and there is no result, it displays the following error : 

> "Something went wrong when running this command, either discord or the bot may be having issues."

It also causes custom commands to stop execution due to error generation. This is an idea to fix this behavior. With above changes, error will not be generated during first run. Max page is also appropriately updated when going to a lower page with a simple change in paginatedmessage.go . Same method can be adopted in other paginated commands that allow specifying page like amod logs.

Pictorial Representation : left button -> left button -> left button -> right button.
![image](https://user-images.githubusercontent.com/56998894/69729568-d482e900-1126-11ea-85fd-369423341faf.png)
![image](https://user-images.githubusercontent.com/56998894/69729605-e6fd2280-1126-11ea-845f-2a21787090cb.png)
![image](https://user-images.githubusercontent.com/56998894/69729641-f8462f00-1126-11ea-8c7d-256ab0355d1f.png)
![image](https://user-images.githubusercontent.com/56998894/69729664-05fbb480-1127-11ea-9296-7e59837818c4.png)

Other Changes : 
Added a Total field to ListViolationsCount
Typo fix /n -> \n and Capitalization Change
