### PR TITLE
Duration parsing

### DIFF
--- a/common/parseduration.go
+++ b/common/parseduration.go
@@ -1,0 +1,91 @@
+// Code duplicated directly from commands/util.go
+package common
+
+import (
+	"strconv"
+	"strings"
+	"time"
+	"unicode"
+
+	"emperror.dev/errors"
+)
+
+// Parses a time string like 1day3h
+func ParseDuration(str string) (time.Duration, error) {
+	var dur time.Duration
+
+	currentNumBuf := ""
+	currentModifierBuf := ""
+
+	// Parse the time
+	for _, v := range str {
+		// Ignore whitespace
+		if unicode.Is(unicode.White_Space, v) {
+			continue
+		}
+
+		if unicode.IsNumber(v) {
+			// If we reached a number and the modifier was also set, parse the last duration component before starting a new one
+			if currentModifierBuf != "" {
+				if currentNumBuf == "" {
+					currentNumBuf = "1"
+				}
+				d, err := parseDurationComponent(currentNumBuf, currentModifierBuf)
+				if err != nil {
+					return d, err
+				}
+
+				dur += d
+
+				currentNumBuf = ""
+				currentModifierBuf = ""
+			}
+
+			currentNumBuf += string(v)
+
+		} else {
+			currentModifierBuf += string(v)
+		}
+	}
+
+	if currentNumBuf != "" {
+		d, err := parseDurationComponent(currentNumBuf, currentModifierBuf)
+		if err != nil {
+			return dur, errors.WrapIf(err, "not a duration")
+		}
+
+		dur += d
+	}
+
+	return dur, nil
+}
+
+func parseDurationComponent(numStr, modifierStr string) (time.Duration, error) {
+	parsedNum, err := strconv.ParseInt(numStr, 10, 64)
+	if err != nil {
+		return 0, err
+	}
+
+	parsedDur := time.Duration(parsedNum)
+
+	if strings.HasPrefix(modifierStr, "s") {
+		parsedDur = parsedDur * time.Second
+	} else if modifierStr == "" || (strings.HasPrefix(modifierStr, "m") && (len(modifierStr) < 2 || modifierStr[1] != 'o')) {
+		parsedDur = parsedDur * time.Minute
+	} else if strings.HasPrefix(modifierStr, "h") {
+		parsedDur = parsedDur * time.Hour
+	} else if strings.HasPrefix(modifierStr, "d") {
+		parsedDur = parsedDur * time.Hour * 24
+	} else if strings.HasPrefix(modifierStr, "w") {
+		parsedDur = parsedDur * time.Hour * 24 * 7
+	} else if strings.HasPrefix(modifierStr, "mo") {
+		parsedDur = parsedDur * time.Hour * 24 * 30
+	} else if strings.HasPrefix(modifierStr, "y") {
+		parsedDur = parsedDur * time.Hour * 24 * 365
+	} else {
+		return parsedDur, errors.New("couldn't figure out what '" + numStr + modifierStr + "` was")
+	}
+
+	return parsedDur, nil
+
+}

--- a/common/templates/general.go
+++ b/common/templates/general.go
@@ -573,8 +573,8 @@ func ToDuration(from interface{}) time.Duration {
 	case uint64:
 		return time.Duration(int64(t))
 	case string:
-		parsed, _ := strconv.ParseInt(t, 10, 64)
-		return time.Duration(parsed)
+		parsed, _ := common.ParseDuration(t)
+		return parsed
 	case time.Duration:
 		return time.Duration(t)
 	default:


### PR DESCRIPTION
due to import cycles with ../commands/, templates directly can not use util.go and it's ParseDuration function. That's why I suggest duplicating that code to common - could also be directly copied to, let's say templates/general.go, but at this point I preferred to keep it separate.

Users really want to have duration conversion also in string form "1w1h", changed the ToDuration function.