### PR TITLE
possible typo fix on database query type

### DIFF
--- a/customcommands/tmplextensions.go
+++ b/customcommands/tmplextensions.go
@@ -288,7 +288,7 @@ func tmplScheduleUniqueCC(ctx *templates.Context) interface{} {
 
 		// since this is a unique, remove existing ones
 		_, err = scheduledmodels.ScheduledEvents(
-			qm.Where("event_name='cc_delayed_run' AND  guild_id = ? AND (data->>'user_key')::bigint = ? AND (data->>'cmd_id')::bigint = ? AND processed = false",
+			qm.Where("event_name='cc_delayed_run' AND  guild_id = ? AND (data->>'user_key')::text = ? AND (data->>'cmd_id')::bigint = ? AND processed = false",
 				ctx.GS.ID, stringedKey, cmd.LocalID)).DeleteAll(context.Background(), common.PQ)
 		if err != nil {
 			return "", err
@@ -314,7 +314,7 @@ func tmplCancelUniqueCC(ctx *templates.Context) interface{} {
 
 		// since this is a unique, remove existing ones
 		_, err := scheduledmodels.ScheduledEvents(
-			qm.Where("event_name='cc_delayed_run' AND  guild_id = ? AND (data->>'user_key')::bigint = ? AND (data->>'cmd_id')::bigint = ? AND processed = false",
+			qm.Where("event_name='cc_delayed_run' AND  guild_id = ? AND (data->>'user_key')::text = ? AND (data->>'cmd_id')::bigint = ? AND processed = false",
 				ctx.GS.ID, stringedKey, ccID)).DeleteAll(context.Background(), common.PQ)
 		if err != nil {
 			return "", err


### PR DESCRIPTION
This might be a typo, because stringedKey value is of type string and database query wants BIGINT. Still works at present state if user presents the "key" as integer - or is this intentional?