### PR TITLE
Clean BugFix

### DIFF
--- a/moderation/commands.go
+++ b/moderation/commands.go
@@ -341,8 +341,8 @@ var ModerationCommands = []*commands.YAGCommand{
 			userFilter := parsed.Args[1].Int64()
 
 			num := parsed.Args[0].Int()
-			if userFilter == 0 || userFilter == parsed.Msg.Author.ID {
-				num++ // Automatically include our own message
+			if (userFilter == 0 || userFilter == parsed.Msg.Author.ID) && parsed.Source != 0 {
+				num++ // Automatically include our own message if not triggeded by exec/execAdmin
 			}
 
 			if num > 100 {


### PR DESCRIPTION
Fix "clean" command bug deleting extra message in some cases with exec/execAdmin .
Refer [#bugs](https://discordapp.com/channels/166207328570441728/214439334089195521/663612392499970058) for details. 
Caused because num was increased even in cases there is no real message triggering the command directly. 