### PR TITLE
quickfix for incorrect punishment DMs

### DIFF
--- a/moderation/punishments.go
+++ b/moderation/punishments.go
@@ -75,14 +75,7 @@ func punish(config *Config, p Punishment, guildID, channelID int64, author *disc
 	gs := bot.State.Guild(true, guildID)
 
 	member, memberNotFound := getMemberWithFallback(gs, user)
-	if !memberNotFound {
-		msg := config.BanMessage
-		if p == PunishmentKick {
-			msg = config.KickMessage
-		}
-		sendPunishDM(config, msg, action, gs, author, member, duration, reason)
-	}
-
+	
 	logLink := ""
 	if channelID != 0 {
 		logLink = CreateLogs(guildID, channelID, author)
@@ -106,6 +99,12 @@ func punish(config *Config, p Punishment, guildID, channelID int64, author *disc
 
 	if err != nil {
 		return err
+	} else if !memberNotFound {
+		msg := config.BanMessage
+		if p == PunishmentKick {
+			msg = config.KickMessage
+		}
+		sendPunishDM(config, msg, action, gs, author, member, duration, reason)
 	}
 
 	logger.Infof("MODERATION: %s %s %s cause %q", author.Username, action.Prefix, user.Username, reason)


### PR DESCRIPTION
Situation: if  user was not punishable due permissions not allowing it, and YAG getting even 403 Forbidden, DM was still sent out to that user that they're kicked/banned.

So to resolve that spam case, just moving if !memberNotFound { ...
into other error checking branch could resolve this