### PR TITLE
addition: .CCRunCount

### DIFF
--- a/customcommands/bot.go
+++ b/customcommands/bot.go
@@ -564,6 +564,7 @@ func ExecuteCustomCommand(cmd *models.CustomCommand, tmplCtx *templates.Context)
 
 	tmplCtx.Name = "CC #" + strconv.Itoa(int(cmd.LocalID))
 	tmplCtx.Data["CCID"] = cmd.LocalID
+	tmplCtx.Data["CCRunCount"] = cmd.RunCount + 1
 
 	csCop := tmplCtx.CS.Copy(true)
 	f := logger.WithFields(logrus.Fields{


### PR DESCRIPTION
Have seen users wanting this, could be useful info outside control panel, so why not add it to the custom commands dot. That +1 is there to count current "launch" as well.

currently users implement their CCcounters through database, so it lessens that a little.