### PR TITLE
Idea: Delete Role Commands from Role Groups

### DIFF
--- a/common/templates/general.go
+++ b/common/templates/general.go
@@ -50,7 +50,7 @@ func StringKeyDictionary(values ...interface{}) (SDict, error) {
 	return SDict(dict), nil
 }
 
-func CreateSlice(values ...interface{}) ([]interface{}, error) {
+func CreateSlice(values ...interface{}) (Slice, error) {
 	slice := make([]interface{}, len(values))
 	for i := 0; i < len(values); i++ {
 		slice[i] = values[i]

--- a/customcommands/assets/customcommands-editcmd.html
+++ b/customcommands/assets/customcommands-editcmd.html
@@ -141,7 +141,7 @@
                                     <div class="col-sm-12">
                                         <div class="form-group">
                                             <label>Trigger</label>
-                                            <input type="text" class="form-control" name="trigger" placeholder="!fun"
+                                            <input type="text" class="form-control" name="trigger" placeholder="fun"
                                                 value="{{.CC.TextTrigger}}">
                                             <div class="checkbox">
                                                 <label>
@@ -254,7 +254,7 @@
                                     {{range .CC.Responses}}
                                     <div class="entry input-group  input-group-sm">
                                         <textarea class="form-control response-text-area" name="responses"
-                                            placeholder="^ Smells!" rows="5"
+                                            placeholder="Command body here" rows="5"
                                             oninput="onCCChanged(this)">{{.}}</textarea>
                                         <span class="input-group-append">
                                             <button class="btn btn-success btn-add btn-circle" type="button">
@@ -265,7 +265,7 @@
                                     {{else}}
                                     <div class="entry input-group  input-group-sm">
                                         <textarea class="form-control response-text-area" name="responses"
-                                            placeholder="^ Smells!" rows="5" oninput="onCCChanged(this)"></textarea>
+                                            placeholder="Command body here" rows="5" oninput="onCCChanged(this)"></textarea>
                                         <span class="input-group-append">
                                             <button class="btn btn-success btn-add btn-circle" type="button">
                                                 <i class="fas fa-plus"></i>

--- a/rolecommands/assets/rolecommands.html
+++ b/rolecommands/assets/rolecommands.html
@@ -339,6 +339,21 @@ $(function(){
         </div>    
     </div>
 </div>
+<div class="row">
+    <div class="col-lg-12">
+        <section class="card card-featured card-featured-danger">
+            <header class="card-header">
+                <h2 class="card-title">Delete all {{len .Commands}} role commands</h2>
+            </header>
+            <div class="card-body">
+                <p>Completely deletes all role commands in this group from the server, <b>CANNOT BE UNDONE!!!</b></p>
+                <form data-async-form action="/manage/{{$ag.ID}}/rolecommands/delete_rolecmds" method="post">
+                    <button type="submit" class="btn btn-danger" formaction="/manage/{{$ag.ID}}/rolecommands/delete_rolecmds?group={{if .Group}}{{.Group.ID}}{{else}}-1{{end}}">Delete all roles from <b>{{if .Group}}{{.Group.Name}}{{else}}Ungrouped{{end}}</b>!</button>
+                </form>
+            </div>
+        </section>
+    </div>
+</div>
 {{end}}{{end}}
 
 {{define "rolecommands_groupopts"}}


### PR DESCRIPTION
This here includes HTML code (without any additional CSS styling) for delete button, which is displayed if there are role commands set in a group + counter of rolecommands in that group. 

HandleDeleteRoleCommands, when invoked will delete the rolecommands only from within that group, group itself still remains there. Also deleting from Ungrouped is possible.

Should not be database heavy.