### PR TITLE
Satty9361 send complex

### DIFF
--- a/common/templates/context.go
+++ b/common/templates/context.go
@@ -57,7 +57,7 @@ var (
 		"sdict":  StringKeyDictionary,
 		"cembed": CreateEmbed,
 		"cslice": CreateSlice,
-		"cmessage": CreateMessage,
+		"cmessage": CreateMessageSend,
 
 		"formatTime":  tmplFormatTime,
 		"json":        tmplJson,

--- a/common/templates/context.go
+++ b/common/templates/context.go
@@ -57,6 +57,7 @@ var (
 		"sdict":  StringKeyDictionary,
 		"cembed": CreateEmbed,
 		"cslice": CreateSlice,
+		"cmessage": CreateMessage,
 
 		"formatTime":  tmplFormatTime,
 		"json":        tmplJson,

--- a/common/templates/context.go
+++ b/common/templates/context.go
@@ -57,7 +57,7 @@ var (
 		"sdict":  StringKeyDictionary,
 		"cembed": CreateEmbed,
 		"cslice": CreateSlice,
-		"cmessage": CreateMessageSend,
+		"complexMessage": CreateMessageSend,
 
 		"formatTime":  tmplFormatTime,
 		"json":        tmplJson,

--- a/common/templates/context_funcs.go
+++ b/common/templates/context_funcs.go
@@ -114,7 +114,7 @@ func (c *Context) tmplSendMessage(filterSpecialMentions bool, returnID bool) fun
 		}
 
 		var m *discordgo.Message
-		var msgSend *discordgo.MessageSend
+		msgSend := &discordgo.MessageSend{}
 		var err error
 
 		switch typedMsg := msg.(type) {

--- a/common/templates/context_funcs.go
+++ b/common/templates/context_funcs.go
@@ -114,18 +114,25 @@ func (c *Context) tmplSendMessage(filterSpecialMentions bool, returnID bool) fun
 		}
 
 		var m *discordgo.Message
+		var msgSend *discordgo.MessageSend
 		var err error
-		if embed, ok := msg.(*discordgo.MessageEmbed); ok {
-			m, err = common.BotSession.ChannelMessageSendEmbed(cid, embed)
-		} else {
-			strMsg := fmt.Sprint(msg)
 
-			if filterSpecialMentions {
-				strMsg = common.EscapeSpecialMentions(strMsg)
-			}
+		switch typedMsg := msg.(type) {
 
-			m, err = common.BotSession.ChannelMessageSend(cid, strMsg)
+			case *discordgo.MessageEmbed:
+				msgSend.Embed = typedMsg
+			case *discordgo.MessageSend:
+				msgSend = typedMsg
+			default:
+				msgSend.Content = fmt.Sprint(msg)
 		}
+
+		if filterSpecialMentions && msgSend.Content != "" {
+			msgSend.Content = common.EscapeSpecialMentions(msgSend.Content)
+		}
+
+		m, err = common.BotSession.ChannelMessageSendComplex(cid, msgSend)
+		
 
 		if err == nil && returnID {
 			return m.ID

--- a/common/templates/general.go
+++ b/common/templates/general.go
@@ -42,8 +42,8 @@ func StringKeyDictionary(values ...interface{}) (SDict, error) {
 			return nil, errors.New("Sdict: nil value passed")
 		} 		
 
-		if val.Type().String() == "templates.SDict" {	
-			return val.Interface().(SDict), nil
+		if sdict, ok := val.(SDict); ok {	
+			return sdict, nil
 		}
 		
 		switch val.Kind() {		
@@ -130,7 +130,7 @@ func CreateEmbed(values ...interface{}) (*discordgo.MessageEmbed, error) {
 	return embed, nil
 }
 
-func CreateMessage(values ...interface{}) (*discordgo.MessageSend, error) {
+func CreateMessageSend(values ...interface{}) (*discordgo.MessageSend, error) {
 	if len(values) < 1 {
 		return &discordgo.MessageSend{}, nil
 	}

--- a/common/templates/general.go
+++ b/common/templates/general.go
@@ -174,7 +174,7 @@ func CreateMessage(values ...interface{}) (*discordgo.MessageSend, error) {
 						Reader: &buf,
 				}
 			default:
-				return nil, errors.New(`invalid key "` + key + `" passed to message builder`)
+				return nil, errors.New(`invalid key "` + key + `" passed to send message builder`)
 		}
 
 	}

--- a/common/templates/general.go
+++ b/common/templates/general.go
@@ -42,7 +42,7 @@ func StringKeyDictionary(values ...interface{}) (SDict, error) {
 			return nil, errors.New("Sdict: nil value passed")
 		} 		
 
-		if sdict, ok := val.(SDict); ok {	
+		if sdict, ok := val.Interface().(SDict); ok {	
 			return sdict, nil
 		}
 		


### PR DESCRIPTION
A new template that creates *discordgo.MessageSend from sdict , maps etc. 

Some changes to sdict conversion now using reflection.

Enable cemebed to handle *discordgo.MessageEmbed sent as argument

Changes to SendMessage function effectively enabling all existing templates ( sendMessage , sendMessageRetID etc.. ) to send Complex messages depending of datatype of argument passed being *discordgo.MessageSend.