### PR TITLE
StringSlice method to convert a Slice to []String

### DIFF
--- a/common/templates/context.go
+++ b/common/templates/context.go
@@ -2,6 +2,7 @@ package templates
 
 import (
 	"bytes"
+	"fmt"
 	"io"
 	"net/url"
 	"reflect"
@@ -531,6 +532,13 @@ func (s Slice) StringSlice (flag ...bool) interface{} {
 		switch t := Sliceval.(type) {
 			case string :
 				StringSlice = append(StringSlice, t)
+			
+			case fmt.Stringer :
+				if strict {
+					return nil
+				}
+				StringSlice = append(StringSlice, t.String())
+			
 			default:
 				if strict {
 					return nil

--- a/common/templates/context.go
+++ b/common/templates/context.go
@@ -518,3 +518,25 @@ func (s Slice) AppendSlice (slice interface{}) (interface{}, error) {
 
 		return result.Interface(), nil
 }
+
+func (s Slice) StringSlice (flag ...bool) interface{} {
+	strict := false
+	if len(flag) > 0 {
+		strict = flag[0]
+	}
+
+	StringSlice := make([]string, 0, len(s))
+	
+	for _, Sliceval := range s {
+		switch t := Sliceval.(type) {
+			case string :
+				StringSlice = append(StringSlice, t)
+			default:
+				if strict {
+					return nil
+				}
+		}	
+	}
+
+	return StringSlice
+}


### PR DESCRIPTION
Quite a few template like joinStr, AddReactions , exec etc accept []string as arguments but not []interface{}. Rather than doing a huge number of changes, I think conversion of Slice to []slice is a good solution. This does not allow any mutation of string slices, just an easy conversion from Slices to []string. I have implemented this using a variadic boolean flag argument which is by default false but can be set to true. If true, and any value of the Slice is not string, execution is stopped and it returns nil. Otherwise it tries to generate a sub-slice of all string values in the Slice. 