### PR TITLE
Tab-key for custom commands

### DIFF
--- a/cmd/yagpdb/static/js/custom.js
+++ b/cmd/yagpdb/static/js/custom.js
@@ -1,2 +1,22 @@
 /* Add here all your JS customizations */
 
+/* This one is meant for tab-indent to be active in all textarea if marked tags; does not feature undo */
+$(document).delegate('.tab-textbox', 'keydown', function(e) { 
+var keyCode = e.keyCode || e.which; 
+
+    if (keyCode == 9) {
+      e.preventDefault();
+      var start = $(this).get(0).selectionStart;
+      var end = $(this).get(0).selectionEnd;
+
+      // caret replacement
+      $(this).val($(this).val().substring(0, start)
+                  + "\t"
+                  + $(this).val().substring(end));
+
+  // caret back
+  $(this).get(0).selectionStart = 
+  $(this).get(0).selectionEnd = start + 1;
+  onCCChanged(this);
+} 
+});

--- a/customcommands/assets/customcommands-editcmd.html
+++ b/customcommands/assets/customcommands-editcmd.html
@@ -253,7 +253,7 @@
                                     <!-- Use .btn-add for simplicity and let the page loader adjust. -->
                                     {{range .CC.Responses}}
                                     <div class="entry input-group  input-group-sm">
-                                        <textarea class="form-control response-text-area" name="responses"
+                                        <textarea class="form-control response-text-area tab-textbox" name="responses"
                                             placeholder="Command body here" rows="5"
                                             oninput="onCCChanged(this)">{{.}}</textarea>
                                         <span class="input-group-append">
@@ -264,7 +264,7 @@
                                     </div>
                                     {{else}}
                                     <div class="entry input-group  input-group-sm">
-                                        <textarea class="form-control response-text-area" name="responses"
+                                        <textarea class="form-control response-text-area tab-textbox" name="responses"
                                             placeholder="Command body here" rows="5" oninput="onCCChanged(this)"></textarea>
                                         <span class="input-group-append">
                                             <button class="btn btn-success btn-add btn-circle" type="button">


### PR DESCRIPTION
Like all front-end things this is "what-if"-case. This implementation does not have a keyboard "undo" but backspace still works. "Tab" creates 8 character width and this is default.

character addition to CC total counter is added

Have run this on Safari, Edge, Chrome, Firefox, Opera, Brave.

needs testing in dev and later this class could be added to other textarea sections in HTML