### PR TITLE
fix incorrect regex for matching.

### DIFF
--- a/customcommands/bot.go
+++ b/customcommands/bot.go
@@ -700,16 +700,16 @@ func CheckMatch(globalPrefix string, cmd *models.CustomCommand, msg string) (mat
 	switch CommandTriggerType(cmd.TriggerType) {
 	case CommandTriggerCommand:
 		// Regex is:
-		// ^(<@!?bot_id> ?|server_cmd_prefix)trigger($|[[:space:]])
-		cmdMatch += "^(<@!?" + discordgo.StrID(common.BotUser.ID) + "> ?|" + regexp.QuoteMeta(globalPrefix) + ")" + regexp.QuoteMeta(trigger) + "($|[[:space:]])"
+		// \A(<@!?bot_id> ?|server_cmd_prefix)trigger(\z|[[:space:]])
+		cmdMatch += "\A(<@!?" + discordgo.StrID(common.BotUser.ID) + "> ?|" + regexp.QuoteMeta(globalPrefix) + ")" + regexp.QuoteMeta(trigger) + "(\z|[[:space:]])"
 	case CommandTriggerStartsWith:
-		cmdMatch += "^" + regexp.QuoteMeta(trigger)
+		cmdMatch += "\A" + regexp.QuoteMeta(trigger)
 	case CommandTriggerContains:
-		cmdMatch += "^.*" + regexp.QuoteMeta(trigger)
+		cmdMatch += "\A.*" + regexp.QuoteMeta(trigger)
 	case CommandTriggerRegex:
 		cmdMatch += trigger
 	case CommandTriggerExact:
-		cmdMatch += "^" + regexp.QuoteMeta(trigger) + "$"
+		cmdMatch += "\A" + regexp.QuoteMeta(trigger) + "\z"
 	default:
 		return false, "", nil
 	}

--- a/customcommands/bot.go
+++ b/customcommands/bot.go
@@ -701,15 +701,15 @@ func CheckMatch(globalPrefix string, cmd *models.CustomCommand, msg string) (mat
 	case CommandTriggerCommand:
 		// Regex is:
 		// \A(<@!?bot_id> ?|server_cmd_prefix)trigger(\z|[[:space:]])
-		cmdMatch += "\A(<@!?" + discordgo.StrID(common.BotUser.ID) + "> ?|" + regexp.QuoteMeta(globalPrefix) + ")" + regexp.QuoteMeta(trigger) + "(\z|[[:space:]])"
+		cmdMatch += `\A(<@!?` + discordgo.StrID(common.BotUser.ID) + "> ?|" + regexp.QuoteMeta(globalPrefix) + ")" + regexp.QuoteMeta(trigger) + `(\z|[[:space:]])`
 	case CommandTriggerStartsWith:
-		cmdMatch += "\A" + regexp.QuoteMeta(trigger)
+		cmdMatch += `\A` + regexp.QuoteMeta(trigger)
 	case CommandTriggerContains:
-		cmdMatch += "\A.*" + regexp.QuoteMeta(trigger)
+		cmdMatch += `\A.*` + regexp.QuoteMeta(trigger)
 	case CommandTriggerRegex:
 		cmdMatch += trigger
 	case CommandTriggerExact:
-		cmdMatch += "\A" + regexp.QuoteMeta(trigger) + "\z"
+		cmdMatch += `\A` + regexp.QuoteMeta(trigger) + `\z`
 	default:
 		return false, "", nil
 	}


### PR DESCRIPTION
^ to \A
and $ to \z
this will always work irrespective of multi line mode being set or reset.