### PR TITLE
Tickets- Include ticket Title in transcripts

### DIFF
--- a/premium/assets/premium.html
+++ b/premium/assets/premium.html
@@ -59,6 +59,7 @@
                                 <li>Max Reddit feeds increased from 100 to 1000</li>
                                 <li>Max Youtube feeds increased from 50 to 250 (Possibly higher if needed)</li>
                                 <li>Max Soundboard sounds increased from 50 to 250 (Possibly higher if needed)</li>
+                                <li>Increased database storage and interaction limits.</li>
                             </ul>
                         </div>
                     </section>

--- a/tickets/tickets_commands.go
+++ b/tickets/tickets_commands.go
@@ -521,7 +521,7 @@ func createLogs(gs *dstate.GuildState, conf *models.TicketConfig, ticket *models
 		formattedTranscript := createTXTTranscript(ticket, msgs)
 
 		channel := transcriptChannel(conf, adminOnly)
-		_, err := common.BotSession.ChannelFileSendWithMessage(channel, fmt.Sprintf("transcript-%d.txt", ticket.LocalID), fmt.Sprintf("transcript-%d.txt", ticket.LocalID), formattedTranscript)
+		_, err := common.BotSession.ChannelFileSendWithMessage(channel, fmt.Sprintf("transcript-%d-%s.txt", ticket.LocalID, ticket.Title), fmt.Sprintf("transcript-%d-%s.txt", ticket.LocalID, ticket.Title), formattedTranscript)
 		if err != nil {
 			return err
 		}
@@ -548,7 +548,7 @@ func archiveAttachments(conf *models.TicketConfig, ticket *models.Ticket, groups
 				continue
 			}
 
-			fName := fmt.Sprintf("attachments-%d-%s", ticket.LocalID, ag[0].Filename)
+			fName := fmt.Sprintf("attachments-%d-%s-%s", ticket.LocalID, ticket.Title, ag[0].Filename)
 			_, err = common.BotSession.ChannelFileSendWithMessage(transcriptChannel(conf, adminOnly),
 				fName, fName, resp.Body)
 			continue
@@ -581,7 +581,7 @@ func archiveAttachments(conf *models.TicketConfig, ticket *models.Ticket, groups
 		}
 
 		zw.Close()
-		fname := fmt.Sprintf("attachments-%d.zip", ticket.LocalID)
+		fname := fmt.Sprintf("attachments-%d-%s.zip", ticket.LocalID, ticket.Title)
 		_, err := common.BotSession.ChannelFileSendWithMessage(transcriptChannel(conf, adminOnly), fname, fname, &buf)
 		buf.Reset()
 


### PR DESCRIPTION
It has been pointed out that finding a transcript using just the ticket number becomes difficult. Adding the ticket title in the filename would resolve this.