### PR TITLE
template function: delete Message Reaction(s)

### DIFF
--- a/common/templates/context.go
+++ b/common/templates/context.go
@@ -383,6 +383,7 @@ func baseContextFuncs(c *Context) {
 	c.ContextFuncs["deleteResponse"] = c.tmplDelResponse
 	c.ContextFuncs["deleteTrigger"] = c.tmplDelTrigger
 	c.ContextFuncs["deleteMessage"] = c.tmplDelMessage
+	c.ContextFuncs["deleteMessageReaction"] = c.tmplDelMessageReaction
 	c.ContextFuncs["deleteAllMessageReactions"] = c.tmplDelAllMessageReactions
 	c.ContextFuncs["getMessage"] = c.tmplGetMessage
 	c.ContextFuncs["getMember"] = c.tmplGetMember

--- a/common/templates/context_funcs.go
+++ b/common/templates/context_funcs.go
@@ -643,7 +643,7 @@ func (c *Context) tmplDelMessageReaction(values ...reflect.Value) (reflect.Value
 
 		for _, reaction := range args[3:] {
 
-			if c.IncreaseCheckCallCounter("del_reaction_message", 20) {
+			if c.IncreaseCheckCallCounter("del_reaction_message", 10) {
 				return reflect.Value{}, ErrTooManyCalls
 			}
 


### PR DESCRIPTION
This is very wished function - I dunno about rate-limits here, it is strictly told to run once per CC, that 20 emote deletions later might be a problem/can be changed to let's say 10. Runs fine on lesser test-server, needs further discussion and testing.