### PR TITLE
templates: comma separator for thousands

### DIFF
--- a/common/templates/context.go
+++ b/common/templates/context.go
@@ -54,6 +54,7 @@ var (
 		"roundCeil":  tmplRoundCeil,
 		"roundFloor": tmplRoundFloor,
 		"roundEven":  tmplRoundEven,
+		"humanizeThousands": tmplHumanizeThousands,
 
 		// misc
 		"dict":   Dictionary,

--- a/common/templates/general.go
+++ b/common/templates/general.go
@@ -453,6 +453,29 @@ func tmplLog(arguments ...interface{}) (float64, error) {
 	return logarithm, nil
 }
 
+//tmplHumanizeThousands comma separates thousands
+func tmplHumanizeThousands(input interface{}) string{
+	var f1,f2 string
+
+	i := tmplToInt(input)
+	str := strconv.Itoa(i)
+	
+	idx := 0
+	for i = len(str) -1; i >= 0; i-- {
+		idx++
+		if idx == 4{
+			idx = 1
+			f1 = f1 + ","
+		}
+		f1=f1+string(str[i])
+	}
+
+	for i=len(f1)-1;i>=0;i--{
+		f2=f2+string(f1[i])
+	}
+	return f2
+}
+
 func roleIsAbove(a, b *discordgo.Role) bool {
 	return dutil.IsRoleAbove(a, b)
 }


### PR DESCRIPTION
Users frequently request this, although this can be done using custom commands. I really don't know why they want this or can't make their own CC, but they, the users cry about this feature constantly.