### PR TITLE
HTML: caret addition to CC card

### DIFF
--- a/customcommands/assets/customcommands.html
+++ b/customcommands/assets/customcommands.html
@@ -6,6 +6,19 @@
         max-height: 500px;
         overflow-y: auto;
     }
+    .cc-collapsibleDown:before{
+        font-family: 'Font Awesome 5 Free';
+        font-weight: 900;
+        content: "\f107";
+        margin-right: 10px;
+    }
+    
+    .cc-collapsibleUp:before{
+        font-family: 'Font Awesome 5 Free';
+        font-weight: 900;
+        content: '\f106';
+        margin-right: 10px;
+    }
 </style>
 
 <header class="page-header">
@@ -126,7 +139,7 @@
                 </div>
             </form>
             <h2 class="card-title">
-                <a style="padding:15px 20px 10px 20px!important" data-toggle="collapse" data-parent="#accordion" href="#collapse_cmd{{.LocalID}}" aria-expanded="false" aria-controls="collapse_cmd{{.LocalID}}">
+                <a style="padding:15px 20px 10px 20px!important" data-toggle="collapse" data-parent="#accordion" href="#collapse_cmd{{.LocalID}}" aria-expanded="false" aria-controls="collapse_cmd{{.LocalID}}" class="cc-collapsibleDown">
                     #{{.LocalID}} - {{index $dot.CCTriggerTypes .TriggerType}}{{if and (ne .TriggerType 10) (ne .TriggerType 5) (ne .TriggerType 6)}}: <span class="cc-text-trigger-span">{{.TextTrigger}}</span>{{else if and (ne .TriggerType 10) (ne .TriggerType 6)}}: <span class="cc-text-interval-span">Every {{call $dot.GetCCInterval .}} {{if eq (call $dot.GetCCIntervalType .) 1}}hour(s)</span>{{else}}minute(s)</span>{{end}} next run: <span class="cc-text-next-run-span">{{.NextRun.Time.UTC.Format "2006-01-02 15:04:05 MST"}}</span>{{end}}
                 </a>
             </h2>
@@ -204,6 +217,10 @@
         hljs.highlightBlock(block);
         hljs.lineNumbersBlock(block);
     });
+    $('.collapse').on('shown.bs.collapse', function(){
+    $(this).parent().find('.cc-collapsibleDown').removeClass('cc-collapsibleDown').addClass('cc-collapsibleUp');}).on('hidden.bs.collapse',function(){
+        $(this).parent().find('.cc-collapsibleUp').removeClass('cc-collapsibleUp').addClass('cc-collapsibleDown');});
+    
 </script>
 {{template "cp_footer" .}}
 


### PR DESCRIPTION
This is the same \f106 \f107 awesome font up-down caret used in navigation panel when folding the panels. Same here.
![caret](https://user-images.githubusercontent.com/37475633/74481133-d2752e80-4eba-11ea-9fc2-80a9d6c25e90.png)
