### PR TITLE
Suggestion: replacing CC awesome icon

### DIFF
--- a/customcommands/web.go
+++ b/customcommands/web.go
@@ -41,7 +41,7 @@ func (p *Plugin) InitWeb() {
 	web.AddSidebarItem(web.SidebarCategoryCore, &web.SidebarItem{
 		Name: "Custom commands",
 		URL:  "customcommands",
-		Icon: "fas fa-exclamation",
+		Icon: "fas fa-closed-captioning",
 	})
 
 	getHandler := web.ControllerHandler(handleCommands, "cp_custom_commands")


### PR DESCRIPTION
Although this new icon means closed captioning, YAGPDB uses this abbreviation for custom commands and seems OK to use it here instead of just plain exclamation mark, which usually means danger : )