### PR TITLE
Suggestion: replace cplogs awesome icon

### DIFF
--- a/web/web.go
+++ b/web/web.go
@@ -341,7 +341,7 @@ func setupRoutes() *goji.Mux {
 	AddSidebarItem(SidebarCategoryCore, &SidebarItem{
 		Name: "Control panel logs",
 		URL:  "cplogs",
-		Icon: "fas fa-cog",
+		Icon: "fas fa-database",
 	})
 
 	for _, plugin := range common.Plugins {


### PR DESCRIPTION
Currently we have two cog icons under Core - representing different things. Also fa-database represents logs in other nav section. So consistency sake let the same database icon represent logs everywhere. 

Side note, I actually \f0c5 fa-copy even better, but let fa-database be current suggestion.