### PR TITLE
Complex message edit

### DIFF
--- a/common/templates/context.go
+++ b/common/templates/context.go
@@ -57,11 +57,12 @@ var (
 		"humanizeThousands": tmplHumanizeThousands,
 
 		// misc
-		"dict":           Dictionary,
-		"sdict":          StringKeyDictionary,
-		"cembed":         CreateEmbed,
-		"cslice":         CreateSlice,
-		"complexMessage": CreateMessageSend,
+		"dict":               Dictionary,
+		"sdict":              StringKeyDictionary,
+		"cembed":             CreateEmbed,
+		"cslice":             CreateSlice,
+		"complexMessage":     CreateMessageSend,
+		"complexMessageEdit": CreateMessageEdit,
 
 		"formatTime":  tmplFormatTime,
 		"json":        tmplJson,

--- a/common/templates/context_funcs.go
+++ b/common/templates/context_funcs.go
@@ -165,6 +165,9 @@ func (c *Context) tmplEditMessage(filterSpecialMentions bool) func(channel inter
 			case *discordgo.MessageEmbed:
 				msgEdit.Embed = typedMsg
 			case *discordgo.MessageEdit:
+				if typedMsg.Content != nil && *typedMsg.Content == "" && typedMsg.Embed != nil && typedMsg.Embed.GetMarshalNil() {
+					return "", errors.New("both content and embed cannot be null")
+				}
 				msgEdit.Content = typedMsg.Content
 				msgEdit.Embed = typedMsg.Embed
 			default:

--- a/common/templates/context_funcs.go
+++ b/common/templates/context_funcs.go
@@ -165,6 +165,7 @@ func (c *Context) tmplEditMessage(filterSpecialMentions bool) func(channel inter
 			case *discordgo.MessageEmbed:
 				msgEdit.Embed = typedMsg
 			case *discordgo.MessageEdit:
+				//If both Embed and string are explicitly set as null, give an error message.
 				if typedMsg.Content != nil && *typedMsg.Content == "" && typedMsg.Embed != nil && typedMsg.Embed.GetMarshalNil() {
 					return "", errors.New("both content and embed cannot be null")
 				}

--- a/common/templates/general.go
+++ b/common/templates/general.go
@@ -182,6 +182,46 @@ func CreateMessageSend(values ...interface{}) (*discordgo.MessageSend, error) {
 	return msg, nil
 }
 
+func CreateMessageEdit(values ...interface{}) (*discordgo.MessageEdit, error) {
+	if len(values) < 1 {
+		return &discordgo.MessageEdit{}, nil
+	}
+
+	if m, ok := values[0].(*discordgo.MessageEdit); len(values) == 1 && ok {
+		return m, nil
+	}
+	messageSdict, err := StringKeyDictionary(values...)
+	if err != nil {
+		return nil, err
+	}
+	msg := &discordgo.MessageEdit{}
+
+	for key, val := range messageSdict {
+
+		switch key {
+			case "content":
+				temp := fmt.Sprint(val)
+				msg.Content = &temp
+			case "embed":
+				if val == nil { 
+					msg.Embed = (&discordgo.MessageEmbed{}).MarshalNil(true)
+					continue
+				}
+				embed, err := CreateEmbed(val)
+				if err != nil {
+					return nil, err
+				}
+				msg.Embed = embed
+			default:
+				return nil, errors.New(`invalid key "` + key + `" passed to message edit builder`)
+		}
+
+	}
+
+	return msg, nil
+
+}
+
 // indirect is taken from 'text/template/exec.go'
 func indirect(v reflect.Value) (rv reflect.Value, isNil bool) {
 	for ; v.Kind() == reflect.Ptr || v.Kind() == reflect.Interface; v = v.Elem() {


### PR DESCRIPTION
This function not only lets you edit both embeds and content at once but also allows for completely removing embeds by passing a nil to "embed" key in message edit builder.