### PR TITLE
Idea: additonal ID flag for topservers command

### DIFF
--- a/stdcommands/topservers/topservers.go
+++ b/stdcommands/topservers/topservers.go
@@ -6,6 +6,7 @@ import (
 	"github.com/jonas747/dcmd"
 	"github.com/jonas747/yagpdb/bot/models"
 	"github.com/jonas747/yagpdb/commands"
+	"github.com/jonas747/yagpdb/common"
 	"github.com/volatiletech/sqlboiler/queries/qm"
 )
 
@@ -17,9 +18,26 @@ var Command = &commands.YAGCommand{
 	Arguments: []*dcmd.ArgDef{
 		&dcmd.ArgDef{Name: "Skip", Help: "Entries to skip", Type: dcmd.Int, Default: 0},
 	},
+	ArgSwitches: []*dcmd.ArgDef{
+		{Switch: "id", Name: "serverID", Type: dcmd.Int},
+	},
 	RunFunc: func(data *dcmd.Data) (interface{}, error) {
 		skip := data.Args[0].Int()
 
+		if data.Switches["id"].Value != nil {
+			type serverIDQuery struct {
+				MemberCount int64
+				Name        string
+				Place       int64
+			}
+			var serverID int64
+			var position serverIDQuery
+			serverID = data.Switch("id").Int64()
+			const q = `SELECT member_count, name, row_number FROM (SELECT *, row_number() OVER (ORDER BY member_count DESC) FROM joined_guilds) AS total WHERE id=$1;`
+			err := common.PQ.QueryRow(q, serverID).Scan(&position.MemberCount, &position.Name, &position.Place)
+			return fmt.Sprintf("```Server with ID %d is placed:\n#%-2d: %-25s (%d members)\n```", serverID, position.Place, position.Name, position.MemberCount), err
+		}
+		
 		results, err := models.JoinedGuilds(qm.OrderBy("member_count desc"), qm.Limit(20), qm.Offset(skip)).AllG(data.Context())
 		if err != nil {
 			return nil, err

--- a/stdcommands/topservers/topservers.go
+++ b/stdcommands/topservers/topservers.go
@@ -33,7 +33,7 @@ var Command = &commands.YAGCommand{
 			var serverID int64
 			var position serverIDQuery
 			serverID = data.Switch("id").Int64()
-			const q = `SELECT member_count, name, row_number FROM (SELECT *, row_number() OVER (ORDER BY member_count DESC) FROM joined_guilds) AS total WHERE id=$1;`
+			const q = `SELECT member_count, name, row_number FROM (SELECT id, member_count, name, row_number() OVER (ORDER BY member_count DESC) FROM joined_guilds) AS total WHERE id=$1;`
 			err := common.PQ.QueryRow(q, serverID).Scan(&position.MemberCount, &position.Name, &position.Place)
 			return fmt.Sprintf("```Server with ID %d is placed:\n#%-2d: %-25s (%d members)\n```", serverID, position.Place, position.Name, position.MemberCount), err
 		}


### PR DESCRIPTION
Users are searching for their server from the TOP and instead of skipping and skipping hundreds of times and making extra queries, an id flagged search is better. Had to add /common to import, because I don't know a way doing nested Selects with sqlboiler.

the query should be trimmed down from * 
I guess, because 400k+ servers is a little different than my testing : )

edit: currently 'left_at IS NULL' is also not included to query, because main command includes these servers from where YAG has left.