### PR TITLE
Fix: whois without arguments does not show status

### DIFF
--- a/logs/plugin_bot.go
+++ b/logs/plugin_bot.go
@@ -82,7 +82,13 @@ var cmdWhois = &commands.YAGCommand{
 		}
 
 		member := commands.ContextMS(parsed.Context())
-		member, _ = bot.GetMember(member.Guild.ID, member.ID)
+		memberCPY := parsed.GS.MemberCopy(true, member.ID)
+		if memberCPY == nil {
+			memberCPY = member
+		} else {
+			member = memberCPY
+		}
+		
 		if parsed.Args[0].Value != nil {
 			member = parsed.Args[0].Value.(*dstate.MemberState)
 		}

--- a/logs/plugin_bot.go
+++ b/logs/plugin_bot.go
@@ -82,6 +82,7 @@ var cmdWhois = &commands.YAGCommand{
 		}
 
 		member := commands.ContextMS(parsed.Context())
+		member, _ = bot.GetMember(member.Guild.ID, member.ID)
 		if parsed.Args[0].Value != nil {
 			member = parsed.Args[0].Value.(*dstate.MemberState)
 		}

--- a/logs/plugin_bot.go
+++ b/logs/plugin_bot.go
@@ -83,9 +83,7 @@ var cmdWhois = &commands.YAGCommand{
 
 		member := commands.ContextMS(parsed.Context())
 		memberCPY := parsed.GS.MemberCopy(true, member.ID)
-		if memberCPY == nil {
-			memberCPY = member
-		} else {
+		if memberCPY != nil {
 			member = memberCPY
 		}
 		


### PR DESCRIPTION
For some odd reason commands.ContextMS(parsed.Context()) does not register PresenceStatus from dstate, maybe due to member Copy - can't remember how it's called...

So this is one possible way solving it.