### PR TITLE
Remove mute duration limits from automod v2

### DIFF
--- a/automod/effects.go
+++ b/automod/effects.go
@@ -393,10 +393,8 @@ func (mute *MuteUserEffect) DataType() interface{} {
 func (mute *MuteUserEffect) UserSettings() []*SettingDef {
 	return []*SettingDef{
 		&SettingDef{
-			Name:    "Duration (minutes)",
+			Name:    "Duration (minutes, 0 for permanent)",
 			Key:     "Duration",
-			Min:     1,
-			Max:     10080, // 7 days
 			Kind:    SettingTypeInt,
 			Default: 10,
 		},

--- a/automod/effects.go
+++ b/automod/effects.go
@@ -395,6 +395,7 @@ func (mute *MuteUserEffect) UserSettings() []*SettingDef {
 		&SettingDef{
 			Name:    "Duration (minutes, 0 for permanent)",
 			Key:     "Duration",
+			Min:  	 0,
 			Kind:    SettingTypeInt,
 			Default: 10,
 		},


### PR DESCRIPTION
mute limits should be also removed from automod v2 to be in sync with current changes.