### PR TITLE
Idea to revamp listroles: nomanaged switch and counter

### DIFF
--- a/stdcommands/listroles/listroles.go
+++ b/stdcommands/listroles/listroles.go
@@ -15,7 +15,7 @@ var Command = &commands.YAGCommand{
 	Name:        "ListRoles",
 	Description: "List roles, their id's, color hex code, and 'mention everyone' perms (useful if you wanna double check to make sure you didn't give anyone mention everyone perms that shouldn't have it)",
 	ArgSwitches: []*dcmd.ArgDef{
-		{Switch: "nomana", Name: "Don't list managed (bot) roles"},
+		{Switch: "nomana", Name: "Don't list managed/bot roles"},
 	},
 
 	RunFunc: func(data *dcmd.Data) (interface{}, error) {

--- a/stdcommands/listroles/listroles.go
+++ b/stdcommands/listroles/listroles.go
@@ -15,14 +15,14 @@ var Command = &commands.YAGCommand{
 	Name:        "ListRoles",
 	Description: "List roles, their id's, color hex code, and 'mention everyone' perms (useful if you wanna double check to make sure you didn't give anyone mention everyone perms that shouldn't have it)",
 	ArgSwitches: []*dcmd.ArgDef{
-		{Switch: "nomana", Name: "Don't list managed/bot roles"},
+		{Switch: "nomanaged", Name: "Don't list managed/bot roles"},
 	},
 
 	RunFunc: func(data *dcmd.Data) (interface{}, error) {
 		var out, outFinal string
 		var noMana bool
 		
-		if data.Switches["nomana"].Value != nil && data.Switches["nomana"].Value.(bool) {
+		if data.Switches["nomanaged"].Value != nil && data.Switches["nomanaged"].Value.(bool) {
 			noMana = true
 		}
 		

--- a/stdcommands/listroles/listroles.go
+++ b/stdcommands/listroles/listroles.go
@@ -14,20 +14,36 @@ var Command = &commands.YAGCommand{
 	CmdCategory: commands.CategoryTool,
 	Name:        "ListRoles",
 	Description: "List roles, their id's, color hex code, and 'mention everyone' perms (useful if you wanna double check to make sure you didn't give anyone mention everyone perms that shouldn't have it)",
+	ArgSwitches: []*dcmd.ArgDef{
+		{Switch: "nomana", Name: "Don't list managed (bot) roles"},
+	},
 
 	RunFunc: func(data *dcmd.Data) (interface{}, error) {
-		out := "(ME = mention everyone perms)\n"
-
+		var out, outFinal string
+		var noMana bool
+		
+		if data.Switches["nomana"].Value != nil && data.Switches["nomana"].Value.(bool) {
+			noMana = true
+		}
+		
 		data.GS.Lock()
 		defer data.GS.Unlock()
 
 		sort.Sort(dutil.Roles(data.GS.Guild.Roles))
-
+		
+		counter := 0
 		for _, r := range data.GS.Guild.Roles {
-			me := r.Permissions&discordgo.PermissionAdministrator != 0 || r.Permissions&discordgo.PermissionMentionEveryone != 0
-			out += fmt.Sprintf("`%-25s: %-19d #%-6x  ME:%5t`\n", r.Name, r.ID, r.Color, me)
+			if noMana && r.Managed {
+				continue
+			} else {
+				counter++
+				me := r.Permissions&discordgo.PermissionAdministrator != 0 || r.Permissions&discordgo.PermissionMentionEveryone != 0
+				out += fmt.Sprintf("`%-25s: %-19d #%-6x  ME:%5t`\n", r.Name, r.ID, r.Color, me)
+			}
 		}
-
-		return out, nil
+		outFinal = fmt.Sprintf("Total role count: %d\n", counter)
+		outFinal += fmt.Sprintf("%s", "(ME = mention everyone perms)\n")
+		outFinal += out
+		return outFinal, nil
 	},
 }


### PR DESCRIPTION
Has -nomana switch to exclude managed/bot roles, also a counter as response on first line.
This all can be done using custom commands, but main-command should also have it.