### PR TITLE
template additions: toRune, toByte

### DIFF
--- a/common/templates/context.go
+++ b/common/templates/context.go
@@ -30,6 +30,8 @@ var (
 		"toInt64":    ToInt64,
 		"toFloat":    ToFloat64,
 		"toDuration": ToDuration,
+		"toRune":     ToRune,
+		"toByte":     ToByte,
 
 		// string manipulation
 		"joinStr":   joinStrings,

--- a/common/templates/general.go
+++ b/common/templates/general.go
@@ -796,6 +796,28 @@ func ToDuration(from interface{}) time.Duration {
 	}
 }
 
+func ToRune(from interface{}) []rune {
+	switch t := from.(type) {
+	case int, int16, int32, int64, uint8, uint16, uint32, uint64, float32, float64:
+		return []rune(ToString(t))
+	case string:
+		return []rune(t)
+	default:
+		return nil
+	}
+}
+
+func ToByte(from interface{}) []byte {
+	switch t := from.(type) {
+	case int, int16, int32, int64, uint8, uint16, uint32, uint64, float32, float64:
+		return []byte(ToString(t))
+	case string:
+		return []byte(t)
+	default:
+		return nil
+	}
+}
+
 func tmplJson(v interface{}) (string, error) {
 	b, err := json.Marshal(v)
 	if err != nil {


### PR DESCRIPTION
Sometimes for further analysis of characters int32 and uin8 are necessary. So these conversion functions are quick way around for that. 

PR'd them together, because these are small changes and together in code.