### PR TITLE
Stop purging messages on ban by default

### DIFF
--- a/moderation/commands.go
+++ b/moderation/commands.go
@@ -134,7 +134,7 @@ var ModerationCommands = []*commands.YAGCommand{
 		},
 		ArgSwitches: []*dcmd.ArgDef{
 			&dcmd.ArgDef{Switch: "d", Default: time.Duration(0), Name: "Duration", Type: &commands.DurationArg{}},
-			&dcmd.ArgDef{Switch: "ddays", Default: 1, Name: "Days", Type: dcmd.Int},
+			&dcmd.ArgDef{Switch: "ddays", Default: 0, Name: "Days", Type: dcmd.Int},
 		},
 		RunFunc: func(parsed *dcmd.Data) (interface{}, error) {
 			config, target, err := MBaseCmd(parsed, parsed.Args[0].Int64())


### PR DESCRIPTION
The current behavior of deleting all messages sent by the banned user in
the past day is not documented anywhere and is undesireable as a default.

This commit sets the default back to 0 days of purged messages, returning
to the behavior of the ban command prior to #549.