### PR TITLE
Satty9361 ban ddays config

### DIFF
--- a/moderation/assets/moderation.html
+++ b/moderation/assets/moderation.html
@@ -346,6 +346,13 @@ the punishment{{end}}
 
         {{checkbox "BanReasonOptional" "BanReasonOptional" "Make the <code>reason</code> optional" .ModConfig.BanReasonOptional}}
         <hr />
+        
+        <div class="form-group">
+            <label>Default number of days of messages to delete while banning. Range 0 to 7.</label>
+            <input type="number" name="DefaultBanDeleteDays.Int64" class="form-control"
+                value="{{.ModConfig.DefaultBanDeleteDays.Int64}}">
+        </div>
+        <hr />
     </div>
     <div class="col-sm">
         <div class="form-group">

--- a/moderation/commands.go
+++ b/moderation/commands.go
@@ -134,7 +134,7 @@ var ModerationCommands = []*commands.YAGCommand{
 		},
 		ArgSwitches: []*dcmd.ArgDef{
 			&dcmd.ArgDef{Switch: "d", Default: time.Duration(0), Name: "Duration", Type: &commands.DurationArg{}},
-			&dcmd.ArgDef{Switch: "ddays", Default: 1, Name: "Days", Type: dcmd.Int},
+			&dcmd.ArgDef{Switch: "ddays", Name: "Days", Type: dcmd.Int},
 		},
 		RunFunc: func(parsed *dcmd.Data) (interface{}, error) {
 			config, target, err := MBaseCmd(parsed, parsed.Args[0].Int64())
@@ -147,8 +147,12 @@ var ModerationCommands = []*commands.YAGCommand{
 			if err != nil {
 				return nil, err
 			}
-
-			err = BanUserWithDuration(config, parsed.GS.ID, parsed.CS, parsed.Msg, parsed.Msg.Author, reason, target, parsed.Switches["d"].Value.(time.Duration), parsed.Switches["ddays"].Int())
+			
+			ddays := int(config.DefaultBanDeleteDays.Int64)
+			if parsed.Switches["ddays"].Value != nil {
+				ddays = parsed.Switches["ddays"].Int()
+			}
+			err = BanUserWithDuration(config, parsed.GS.ID, parsed.CS, parsed.Msg, parsed.Msg.Author, reason, target, parsed.Switches["d"].Value.(time.Duration), ddays)
 			if err != nil {
 				return nil, err
 			}

--- a/moderation/models.go
+++ b/moderation/models.go
@@ -23,10 +23,11 @@ type Config struct {
 	KickMessage          string `valid:"template,5000"`
 
 	// Ban
-	BanEnabled        bool
-	BanCmdRoles       pq.Int64Array `gorm:"type:bigint[]" valid:"role,true"`
-	BanReasonOptional bool
-	BanMessage        string `valid:"template,5000"`
+	BanEnabled        	bool
+	BanCmdRoles       	pq.Int64Array `gorm:"type:bigint[]" valid:"role,true"`
+	BanReasonOptional 	bool
+	BanMessage        	string `valid:"template,5000"`
+	DefaultBanDeleteDays    sql.NullInt64 `gorm:"default:1" valid:"0,7"`
 
 	// Mute/unmute
 	MuteEnabled             bool

--- a/moderation/plugin_web.go
+++ b/moderation/plugin_web.go
@@ -66,6 +66,7 @@ func HandlePostModeration(w http.ResponseWriter, r *http.Request) (web.TemplateD
 
 	newConfig := ctx.Value(common.ContextKeyParsedForm).(*Config)
 	newConfig.DefaultMuteDuration.Valid = true
+	newConfig.DefaultBanDeleteDays.Valid = true
 	templateData["ModConfig"] = newConfig
 
 	err := newConfig.Save(activeGuild.ID)

--- a/web/validation.go
+++ b/web/validation.go
@@ -25,6 +25,7 @@ package web
 //
 // if the struct also implements CustomValidator then that will also be ran
 import (
+	"database/sql"
 	"errors"
 	"fmt"
 	"reflect"
@@ -120,6 +121,13 @@ func ValidateForm(guild *discordgo.Guild, tmpl TemplateData, form interface{}) b
 			if err == nil && !keep {
 				vField.SetInt(0)
 			}
+		case sql.NullInt64:
+			var keep bool
+			var newNullInt sql.NullInt64
+			keep, err = ValidateIntField(cv.Int64, validationTag, guild, false)
+			if err == nil && !keep {
+				vField.Set(reflect.ValueOf(newNullInt))
+			} 
 		case float64:
 			min, max := readMinMax(validationTag)
 			err = ValidateFloatField(cv, min, max)


### PR DESCRIPTION
This adds a default number of days of messages to delete while banning- which is much requested by users.

This is a better solution than #670  as it doesnt change behavior in existing servers while letting people set their own default per server. 

Should work reasonably fine from testing , however I am not 100% sure about the changes in validation.go for a general purpose, for this - it works as desired.