### PR TITLE
Satty9361 struct to sdict

### DIFF
--- a/common/templates/context.go
+++ b/common/templates/context.go
@@ -61,6 +61,7 @@ var (
 		// misc
 		"dict":               Dictionary,
 		"sdict":              StringKeyDictionary,
+		"structToSdict":      StructToSdict,
 		"cembed":             CreateEmbed,
 		"cslice":             CreateSlice,
 		"complexMessage":     CreateMessageSend,

--- a/common/templates/general.go
+++ b/common/templates/general.go
@@ -86,6 +86,29 @@ func StringKeyDictionary(values ...interface{}) (SDict, error) {
 	return SDict(dict), nil
 }
 
+func StructToSdict (value interface{}) (SDict, error) {
+
+	val, isNil := indirect(reflect.ValueOf(value))
+	typeOfS := val.Type()
+	if isNil || value == nil {
+		return nil, errors.New("Expected - struct, got - Nil ")
+	}
+
+	if val.Kind() != reflect.Struct {
+		return nil, errors.New(fmt.Sprintf("Expected - struct, got - %s", val.Type().String()))
+	}
+
+	fields := make(map[string]interface{})
+	for i := 0 ; i < val.NumField() ; i++ {
+		curr := val.Field(i)
+		if curr.CanSet() {
+			fields[typeOfS.Field(i).Name] = curr.Interface()
+		}
+	}
+	return SDict(fields), nil		
+			
+}
+
 func CreateSlice(values ...interface{}) (Slice, error) {
 	slice := make([]interface{}, len(values))
 	for i := 0; i < len(values); i++ {


### PR DESCRIPTION
This is a convenience function to convert exported field-value pairs of a struct to an sdict. It would be very handy for editing embeds and such rather than having to reconstruct the embed field by field manually. Can also be used in finding values because you can range though an sdict and not a struct and a couple other use cases. 

There are already some rather hacky ways of doing this (save to database and retrieve it) but this is better as it preserves datatypes as well as unnecessary database calls.