### PR TITLE
Add fmt.Stringer to toString

### DIFF
--- a/common/templates/general.go
+++ b/common/templates/general.go
@@ -740,6 +740,8 @@ func ToString(from interface{}) string {
 		return string(t)
 	case []byte:
 		return string(t)
+	case fmt.Stringer:
+		return t.String()
 	case string:
 		return t
 	default:


### PR DESCRIPTION
Helpful for consistency as fmt.Stringer works with joinStr and other inbuilt functions already.