### PR TITLE
Update to the Clean Command

### DIFF
--- a/moderation/commands.go
+++ b/moderation/commands.go
@@ -907,9 +907,9 @@ func AdvancedDeleteMessages(channelID int64, filterUser int64, regex string, toI
 			}
 		}
 
-		// Break if msg is equal to the toID one
-		if toID == msgs[i].ID {
-			break
+		// Continue only if current msg ID is < toID
+		if toID > msgs[i].ID {
+			continue
 		}
 
 		toDelete = append(toDelete, msgs[i].ID)


### PR DESCRIPTION
Added a -to flag to the clean command.

This allows users to clean all msgs untill a certain msg by specifying its ID. 

For example: -clean 100 -to 704152928381960284
If there are only 5 msgs until the msg 704152928381960284, it will only clean 5 msgs. 