### PR TITLE
Satty9361 unban

### DIFF
--- a/moderation/assets/moderation.html
+++ b/moderation/assets/moderation.html
@@ -323,16 +323,18 @@ the punishment{{end}}
     <li>You can ban using user ids (even if they left the server)</li>
     <li>You can put a duration on the bans</li>
 </ul>
-<p>Note that the bans themselves are on discord, to unban someone you need to go into your banlist on discord
-    and unban them.</p>
+<p>Note that the bans themselves are on discord. To unban someone you can run the unban command 
+    <code>unban @user somereason</code> or <code> unban 1034924032 somereason</code> or go into 
+    your banlist on discord and unban them.</p>
 <div class="row">
     <div class="col-sm">
-        {{checkbox "BanEnabled" "BanEnabled" "Enable the Ban command" .ModConfig.BanEnabled}}
+        {{checkbox "BanEnabled" "BanEnabled" "Enable the Ban/Unban commands" .ModConfig.BanEnabled}}
         <p>
-            <code>ban @user some reason</code><br />
+            <code>ban/unban @user some reason</code><br />
             Only users with ban permission can use this. (or with roles specified below)<br />
             The ban command will ban a user as well as sending a message that the user was banned in the
-            action channel.
+            action channel.The unban command unbans a banned user and optionally sends a message to the
+	    action channel.
         </p>
         <hr />
 

--- a/moderation/assets/moderation.html
+++ b/moderation/assets/moderation.html
@@ -333,7 +333,7 @@ the punishment{{end}}
             <code>ban/unban @user some reason</code><br />
             Only users with ban permission can use this. (or with roles specified below)<br />
             The ban command will ban a user as well as sending a message that the user was banned in the
-            action channel.The unban command unbans a banned user and optionally sends a message to the
+            action channel. The unban command unbans a banned user and optionally sends a message to the
 	    action channel.
         </p>
         <hr />

--- a/moderation/commands.go
+++ b/moderation/commands.go
@@ -167,8 +167,9 @@ var ModerationCommands = []*commands.YAGCommand{
 			&dcmd.ArgDef{Name: "User", Type: dcmd.UserID},
 			&dcmd.ArgDef{Name: "Reason", Type: dcmd.String},
 		},
+		
 		RunFunc: func(parsed *dcmd.Data) (interface{}, error) {
-			config, target, err := MBaseCmd(parsed, parsed.Args[0].Int64())
+			config, _, err := MBaseCmd(parsed, 0) //in most situations, the target will not be a part of server, hence no point in doing unnecessary api calls(i.e. bot.GetMember)
 			if err != nil {
 				return nil, err
 			}
@@ -177,6 +178,16 @@ var ModerationCommands = []*commands.YAGCommand{
 			reason, err = MBaseCmdSecond(parsed, reason, config.BanReasonOptional, discordgo.PermissionBanMembers, config.BanCmdRoles, config.BanEnabled)
 			if err != nil {
 				return nil, err
+			}
+			targetID := parsed.Args[0].Int64()
+			target := &discordgo.User{
+					Username:      "unknown",
+					Discriminator: "????",
+					ID:            targetID,
+				  }
+			targetMem := parsed.GS.MemberCopy(true, targetID)
+			if targetMem != nil {
+				target = targetMem.DGoUser()
 			}
 
 			isNotBanned, err := UnbanUser(config, parsed.GS.ID, parsed.Msg.Author, reason, target)

--- a/moderation/commands.go
+++ b/moderation/commands.go
@@ -169,7 +169,7 @@ var ModerationCommands = []*commands.YAGCommand{
 		},
 		
 		RunFunc: func(parsed *dcmd.Data) (interface{}, error) {
-			config, _, err := MBaseCmd(parsed, 0) //in most situations, the target will not be a part of server, hence no point in doing unnecessary api calls(i.e. bot.GetMember)
+			config, _, err := MBaseCmd(parsed, 0) //No need to check member role hierarchy as banned members should not be in server
 			if err != nil {
 				return nil, err
 			}
@@ -185,7 +185,7 @@ var ModerationCommands = []*commands.YAGCommand{
 					Discriminator: "????",
 					ID:            targetID,
 				  }
-			targetMem := parsed.GS.MemberCopy(true, targetID)
+			targetMem, _ := bot.GetMember(parsed.GS.ID, targetID)
 			if targetMem != nil {
 				return "User is not banned!", nil
 			}

--- a/moderation/commands.go
+++ b/moderation/commands.go
@@ -159,6 +159,41 @@ var ModerationCommands = []*commands.YAGCommand{
 	&commands.YAGCommand{
 		CustomEnabled: true,
 		CmdCategory:   commands.CategoryModeration,
+		Name:          "Unban",
+		Aliases:       []string{"unbanid"},
+		Description:   "Unbans a user. Reason requirement is same as ban command setting.",
+		RequiredArgs:  1,
+		Arguments: []*dcmd.ArgDef{
+			&dcmd.ArgDef{Name: "User", Type: dcmd.UserID},
+			&dcmd.ArgDef{Name: "Reason", Type: dcmd.String},
+		},
+		RunFunc: func(parsed *dcmd.Data) (interface{}, error) {
+			config, target, err := MBaseCmd(parsed, parsed.Args[0].Int64())
+			if err != nil {
+				return nil, err
+			}
+
+			reason := SafeArgString(parsed, 1)
+			reason, err = MBaseCmdSecond(parsed, reason, config.BanReasonOptional, discordgo.PermissionBanMembers, config.BanCmdRoles, config.BanEnabled)
+			if err != nil {
+				return nil, err
+			}
+
+			isNotBanned, err := UnbanUser(config, parsed.GS.ID, parsed.Msg.Author, reason, target)
+			
+			if err != nil {
+				return nil, err
+			}
+			if isNotBanned {
+				return "User is not banned!", nil
+			}
+
+			return GenericCmdResp(MAUnbanned, target, 0, true, true), nil
+		},
+	},
+	&commands.YAGCommand{
+		CustomEnabled: true,
+		CmdCategory:   commands.CategoryModeration,
 		Name:          "Kick",
 		Description:   "Kicks a member",
 		RequiredArgs:  1,

--- a/moderation/commands.go
+++ b/moderation/commands.go
@@ -187,7 +187,7 @@ var ModerationCommands = []*commands.YAGCommand{
 				  }
 			targetMem := parsed.GS.MemberCopy(true, targetID)
 			if targetMem != nil {
-				target = targetMem.DGoUser()
+				return "User is not banned!", nil
 			}
 
 			isNotBanned, err := UnbanUser(config, parsed.GS.ID, parsed.Msg.Author, reason, target)

--- a/moderation/plugin_bot.go
+++ b/moderation/plugin_bot.go
@@ -236,8 +236,13 @@ func HandleGuildBanAddRemove(evt *eventsystem.EventData) {
 		var i int
 		common.RedisPool.Do(radix.Cmd(&i, "GET", RedisKeyUnbannedUser(guildID, user.ID)))
 		if i > 0 {
-			// The bot was the one that performed the unban
+			// The bot was the one that performed the unban 
 			common.RedisPool.Do(radix.Cmd(nil, "DEL", RedisKeyUnbannedUser(guildID, user.ID)))
+			if i == 2 {
+				//Bot perfrmed non-scheduled unban, don't make duplicate entries in the modlog
+				return
+			}
+			// Bot perfermed scheduled unban, modlog entry must be handled
 			botPerformed = true
 		}
 

--- a/moderation/plugin_bot.go
+++ b/moderation/plugin_bot.go
@@ -239,10 +239,10 @@ func HandleGuildBanAddRemove(evt *eventsystem.EventData) {
 			// The bot was the one that performed the unban 
 			common.RedisPool.Do(radix.Cmd(nil, "DEL", RedisKeyUnbannedUser(guildID, user.ID)))
 			if i == 2 {
-				//Bot perfrmed non-scheduled unban, don't make duplicate entries in the modlog
+				//Bot performed non-scheduled unban, don't make duplicate entries in the modlog
 				return
 			}
-			// Bot perfermed scheduled unban, modlog entry must be handled
+			// Bot performed scheduled unban, modlog entry must be handled
 			botPerformed = true
 		}
 

--- a/moderation/punishments.go
+++ b/moderation/punishments.go
@@ -301,7 +301,7 @@ func UnbanUser(config *Config, guildID int64, author *discordgo.User, reason str
 	
 	err = common.BotSession.GuildBanDelete(guildID, user.ID)
 	if err != nil {
-		notbanned, err := checkErr(err)
+		notbanned, err := isNotFound(err)
 		return notbanned, err
 	}
 	

--- a/moderation/punishments.go
+++ b/moderation/punishments.go
@@ -284,10 +284,6 @@ func UnbanUser(config *Config, guildID int64, author *discordgo.User, reason str
 	//Delete all future Unban Events
 	_, err = seventsmodels.ScheduledEvents(qm.Where("event_name='moderation_unban' AND  guild_id = ? AND (data->>'user_id')::bigint = ?", guildID, user.ID)).DeleteAll(context.Background(), common.PQ)
 	common.LogIgnoreError(err, "[moderation] failed clearing unban events", nil)
-
-	if user.Discriminator != "????" {
-		return true, nil	 //Valid discriminator is present only if Member is already a part of Guild State and hence not banned.
-	}
 	
 	//We need details for user only if unban is to be logged in modlog. Thus we can save a potential api call by directly attempting an unban in other cases.
 	if config.LogUnbans && config.IntActionChannel() != 0 {

--- a/moderation/punishments.go
+++ b/moderation/punishments.go
@@ -290,7 +290,7 @@ func UnbanUser(config *Config, guildID int64, author *discordgo.User, reason str
 		// check if they're already banned
 		guildBan, err := common.BotSession.GuildBan(guildID, user.ID)
 		if err != nil {
-			notbanned, err := checkErr(err)
+			notbanned, err := isNotFound(err)
 			return notbanned, err
 		}
 		user = guildBan.User
@@ -314,7 +314,7 @@ func UnbanUser(config *Config, guildID int64, author *discordgo.User, reason str
 	return false, err
 }
 
-func checkErr (err error) (bool, error) {
+func isNotFound (err error) (bool, error) {
 	if err != nil {
 		if cast, ok := err.(*discordgo.RESTError); ok && cast.Response != nil {
 			if cast.Response.StatusCode == 404 {

--- a/moderation/punishments.go
+++ b/moderation/punishments.go
@@ -294,8 +294,8 @@ func UnbanUser(config *Config, guildID int64, author *discordgo.User, reason str
 		// check if they're already banned
 		guildBan, err := common.BotSession.GuildBan(guildID, user.ID)
 		if err != nil {
-			membool, err := checkErr(err)
-			return membool, err
+			notbanned, err := checkErr(err)
+			return notbanned, err
 		}
 		user = guildBan.User
 	}
@@ -305,8 +305,8 @@ func UnbanUser(config *Config, guildID int64, author *discordgo.User, reason str
 	
 	err = common.BotSession.GuildBanDelete(guildID, user.ID)
 	if err != nil {
-		membool, err := checkErr(err)
-		return membool, err
+		notbanned, err := checkErr(err)
+		return notbanned, err
 	}
 	
 	logger.Infof("MODERATION: %s %s %s cause %q", author.Username, action.Prefix, user.Username, reason)

--- a/moderation/punishments.go
+++ b/moderation/punishments.go
@@ -286,37 +286,49 @@ func UnbanUser(config *Config, guildID int64, author *discordgo.User, reason str
 	common.LogIgnoreError(err, "[moderation] failed clearing unban events", nil)
 
 	if user.Discriminator != "????" {
-		return true, nil	 //Valid discriminator is present only if Member is already a part of Server and hence not banned.
+		return true, nil	 //Valid discriminator is present only if Member is already a part of Guild State and hence not banned.
 	}
 	
-	// check if they're already banned
-	guildBan, err := common.BotSession.GuildBan(guildID, user.ID)
-	
-	if err != nil {
-		if cast, ok := err.(*discordgo.RESTError); ok && cast.Response != nil {
-			if cast.Response.StatusCode == 404 {
-				return true, nil // Not banned, ban not found
-			}
+	//We need details for user only if unban is to be logged in modlog. Thus we can save a potential api call by directly attempting an unban in other cases.
+	if config.LogUnbans && config.IntActionChannel() != 0 {
+		// check if they're already banned
+		guildBan, err := common.BotSession.GuildBan(guildID, user.ID)
+		if err != nil {
+			membool, err := checkErr(err)
+			return membool, err
 		}
-		return false, err
+		user = guildBan.User
 	}
-	user = guildBan.User
 		
 	// Set a key in redis that marks that this user has appeared in the modlog already
 	common.RedisPool.Do(radix.FlatCmd(nil, "SETEX", RedisKeyUnbannedUser(guildID, user.ID), 30, 2))	
 	
 	err = common.BotSession.GuildBanDelete(guildID, user.ID)
 	if err != nil {
-		return false, err
+		membool, err := checkErr(err)
+		return membool, err
 	}
 	
 	logger.Infof("MODERATION: %s %s %s cause %q", author.Username, action.Prefix, user.Username, reason)
 	
 	//modLog Entry handling
-	err = CreateModlogEmbed(config, author, action, user, reason, "")
+	if config.LogUnbans {
+		err = CreateModlogEmbed(config, author, action, user, reason, "")
+	}
 	return false, err
 }
 
+func checkErr (err error) (bool, error) {
+	if err != nil {
+		if cast, ok := err.(*discordgo.RESTError); ok && cast.Response != nil {
+			if cast.Response.StatusCode == 404 {
+				return true, nil // Not found
+			}
+		}
+		return false, err
+	}
+	return false, nil
+}
 const (
 	ErrNoMuteRole = errors.Sentinel("No mute role")
 )


### PR DESCRIPTION
Much requested moderation unban command. Yag is used as primary moderation bot in several servers and I think its will be immensely helpful to have a formal unban command rather than using workarounds with duration and such. Also, helps in adding unban reasons for modlog for manual unbans.

Inherits same settings and permission requirements as the ban command.