### PR TITLE
Satty9361 role edit

### DIFF
--- a/stdcommands/editrole/editrole.go
+++ b/stdcommands/editrole/editrole.go
@@ -37,10 +37,8 @@ var Command = &commands.YAGCommand{
 }
 
 func cmdFuncEditRole(data *dcmd.Data) (interface{}, error) {
-	authorMember := dstate.MSFromDGoMember(data.GS, data.Msg.Member)
 	cID := data.CS.ID
-
-	if ok, err := bot.AdminOrPermMS(cID, authorMember, discordgo.PermissionManageRoles); err != nil {
+	if ok, err := bot.AdminOrPermMS(cID, data.MS, discordgo.PermissionManageRoles); err != nil {
 		return "Failed checking perms", err
 	} else if !ok {
 		return "You need manage roles perms to use this command", nil
@@ -54,7 +52,7 @@ func cmdFuncEditRole(data *dcmd.Data) (interface{}, error) {
 	}
 	
 	data.GS.RLock()
-	if !bot.IsMemberAboveRole(data.GS, authorMember, role) {
+	if !bot.IsMemberAboveRole(data.GS, data.MS, role) {
 		data.GS.RUnlock()
 		return "Can't edit roles above you", nil
 	}

--- a/stdcommands/editrole/editrole.go
+++ b/stdcommands/editrole/editrole.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/jonas747/dcmd"
 	"github.com/jonas747/discordgo"
+	"github.com/jonas747/dstate"
 	"github.com/jonas747/yagpdb/bot"
 	"github.com/jonas747/yagpdb/commands"
 	"github.com/jonas747/yagpdb/common"
@@ -36,7 +37,10 @@ var Command = &commands.YAGCommand{
 }
 
 func cmdFuncEditRole(data *dcmd.Data) (interface{}, error) {
-	if ok, err := bot.AdminOrPerm(discordgo.PermissionManageRoles, data.Msg.Author.ID, data.CS.ID); err != nil {
+	authorMember := dstate.MSFromDGoMember(data.GS, data.Msg.Member)
+	cID := data.CS.ID
+
+	if ok, err := bot.AdminOrPermMS(cID, authorMember, discordgo.PermissionManageRoles); err != nil {
 		return "Failed checking perms", err
 	} else if !ok {
 		return "You need manage roles perms to use this command", nil
@@ -49,7 +53,6 @@ func cmdFuncEditRole(data *dcmd.Data) (interface{}, error) {
 		return "No role with the Name or ID`" + roleS + "` found", nil
 	}
 	
-	authorMember := commands.ContextMS(data.Context())
 	data.GS.RLock()
 	if !bot.IsMemberAboveRole(data.GS, authorMember, role) {
 		data.GS.RUnlock()
@@ -58,7 +61,6 @@ func cmdFuncEditRole(data *dcmd.Data) (interface{}, error) {
 	data.GS.RUnlock()
 
 
-	cID := data.CS.ID
 	change := false
 	
 	name := role.Name

--- a/stdcommands/editrole/editrole.go
+++ b/stdcommands/editrole/editrole.go
@@ -7,7 +7,6 @@ import (
 
 	"github.com/jonas747/dcmd"
 	"github.com/jonas747/discordgo"
-	"github.com/jonas747/dstate"
 	"github.com/jonas747/yagpdb/bot"
 	"github.com/jonas747/yagpdb/commands"
 	"github.com/jonas747/yagpdb/common"

--- a/stdcommands/editrole/editrole.go
+++ b/stdcommands/editrole/editrole.go
@@ -18,7 +18,7 @@ import (
 var Command = &commands.YAGCommand{
 	CmdCategory:     commands.CategoryTool,
 	Name:            "EditRole",
-	Aliases:         []string{"erole"},
+	Aliases:         []string{"ERole"},
 	Description:     "Edits a role",
 	LongDescription: "Requires the manage roles permission and the bot and your highest role being above the edited role",
 	RequiredArgs:    1,
@@ -32,11 +32,11 @@ var Command = &commands.YAGCommand{
 				&dcmd.ArgDef{Switch: "hoist", Help: "Role Hoisted - 1 for true 0 for false", Type: &dcmd.IntArg{Min:0, Max:1}},
 
 	},
-	RunFunc:            cmdFuncMentionRole,
+	RunFunc: 	    cmdFuncEditRole,
 	GuildScopeCooldown: 15,
 }
 
-func cmdFuncMentionRole(data *dcmd.Data) (interface{}, error) {
+func cmdFuncEditRole(data *dcmd.Data) (interface{}, error) {
 	if ok, err := bot.AdminOrPerm(discordgo.PermissionManageRoles, data.Msg.Author.ID, data.CS.ID); err != nil {
 		return "Failed checking perms", err
 	} else if !ok {

--- a/stdcommands/editrole/editrole.go
+++ b/stdcommands/editrole/editrole.go
@@ -1,0 +1,153 @@
+package editrole
+
+import (
+	"fmt"
+	"strconv"
+	"strings"
+
+	"github.com/jonas747/dcmd"
+	"github.com/jonas747/discordgo"
+	"github.com/jonas747/yagpdb/bot"
+	"github.com/jonas747/yagpdb/commands"
+	"github.com/jonas747/yagpdb/common"
+	"github.com/jonas747/yagpdb/moderation"
+	"golang.org/x/image/colornames"
+)
+
+
+var Command = &commands.YAGCommand{
+	CmdCategory:     commands.CategoryTool,
+	Name:            "EditRole",
+	Aliases:         []string{"erole"},
+	Description:     "Edits a role",
+	LongDescription: "Requires the manage roles permission and the bot and your highest role being above the edited role",
+	RequiredArgs:    1,
+	Arguments: []*dcmd.ArgDef{
+		{Name: "Role", Type: dcmd.String},
+	},
+	ArgSwitches: []*dcmd.ArgDef{
+				&dcmd.ArgDef{Switch: "name", Help: "Role name - String", Type: dcmd.String, Default: ""},
+				&dcmd.ArgDef{Switch: "color", Help: "Role color - Either hex code or name", Type: dcmd.String, Default: ""},
+				&dcmd.ArgDef{Switch: "mention", Help: "Role Mentionable - 1 for true 0 for false", Type: &dcmd.IntArg{Min:0, Max:1}},
+				&dcmd.ArgDef{Switch: "hoist", Help: "Role Hoisted - 1 for true 0 for false", Type: &dcmd.IntArg{Min:0, Max:1}},
+
+	},
+	RunFunc:            cmdFuncMentionRole,
+	GuildScopeCooldown: 15,
+}
+
+func cmdFuncMentionRole(data *dcmd.Data) (interface{}, error) {
+	if ok, err := bot.AdminOrPerm(discordgo.PermissionManageRoles, data.Msg.Author.ID, data.CS.ID); err != nil {
+		return "Failed checking perms", err
+	} else if !ok {
+		return "You need manage roles perms to use this command", nil
+	}
+
+	roleS := data.Args[0].Str()
+	role := moderation.FindRole(data.GS, roleS)
+
+	if role == nil {
+		return "No role with the Name or ID`" + roleS + "` found", nil
+	}
+	
+	authorMember := commands.ContextMS(data.Context())
+	data.GS.RLock()
+	if !bot.IsMemberAboveRole(data.GS, authorMember, role) {
+		data.GS.RUnlock()
+		return "Can't edit roles above you", nil
+	}
+	data.GS.RUnlock()
+
+
+	cID := data.CS.ID
+	change := false
+	
+	name := role.Name
+	if n := data.Switch("name").Str(); n != "" {
+		name = limitString(n, 100)
+		change = true
+	}
+	color := role.Color
+	if c := data.Switch("color").Str(); c != "" {
+		parsedColor, ok := ParseColor(c)
+		if !ok {
+			return "Unknown color: " + c + ", can be either hex color code or name for a known color", nil
+		}
+		color = parsedColor
+		change = true
+	}
+	mentionable := role.Mentionable
+	if m := data.Switch("mention"); m != nil {
+		mentionable = m.Bool()
+		change = true
+	}
+	hoisted := role.Hoist
+	if h := data.Switch("hoist"); h != nil {
+		hoisted = h.Bool()
+		change = true
+	}
+
+	if change {
+		_, err := common.BotSession.GuildRoleEdit(data.GS.ID, role.ID, name, color, hoisted, role.Permissions, mentionable)
+		if err != nil {
+			return nil, err
+		}
+	}
+
+	_, err := common.BotSession.ChannelMessageSendComplex(cID, &discordgo.MessageSend{
+		Content: fmt.Sprintf("__**Edited Role(%d) properties to :**__\n\n**Name **: `%s`\n**Color **: `%d`\n**Mentionable **: `%t`\n**Hoisted **: `%t`", role.ID, name, color, mentionable, hoisted),
+		AllowedMentions: discordgo.AllowedMentions{},
+	})
+
+	if err != nil {
+		return nil, err
+	}
+
+	return nil, err
+}
+
+
+func ParseColor(raw string) (int, bool) {
+	if strings.HasPrefix(raw, "#") {
+		raw = raw[1:]
+	}
+
+	// try to parse as hex color code first
+	parsed, err := strconv.ParseInt(raw, 16, 32)
+	if err == nil {
+		temp := int(parsed)
+		if temp > 16777215 {
+			temp = 16777215
+		}
+		return temp, true
+	}
+
+	// look up the color code table
+	for _, v := range colornames.Names {
+		if strings.EqualFold(v, raw) {
+			cStruct := colornames.Map[v]
+
+			color := (int(cStruct.R) << 16) | (int(cStruct.G) << 8) | int(cStruct.B)
+			return color, true
+		}
+	}
+
+	return 0, false
+}
+
+// limitstring cuts off a string at max l length, supports multi byte characters
+func limitString(s string, l int) string {
+	if len(s) <= l {
+		return s
+	}
+
+	lastValidLoc := 0
+	for i, _ := range s {
+		if i > l {
+			break
+		}
+		lastValidLoc = i
+	}
+
+	return s[:lastValidLoc]
+}

--- a/stdcommands/editrole/editrole.go
+++ b/stdcommands/editrole/editrole.go
@@ -30,7 +30,6 @@ var Command = &commands.YAGCommand{
 				&dcmd.ArgDef{Switch: "color", Help: "Role color - Either hex code or name", Type: dcmd.String, Default: ""},
 				&dcmd.ArgDef{Switch: "mention", Help: "Role Mentionable - 1 for true 0 for false", Type: &dcmd.IntArg{Min:0, Max:1}},
 				&dcmd.ArgDef{Switch: "hoist", Help: "Role Hoisted - 1 for true 0 for false", Type: &dcmd.IntArg{Min:0, Max:1}},
-
 	},
 	RunFunc: 	    cmdFuncEditRole,
 	GuildScopeCooldown: 15,

--- a/stdcommands/stdcommands.go
+++ b/stdcommands/stdcommands.go
@@ -18,6 +18,7 @@ import (
 	"github.com/jonas747/yagpdb/stdcommands/dcallvoice"
 	"github.com/jonas747/yagpdb/stdcommands/define"
 	"github.com/jonas747/yagpdb/stdcommands/dogfact"
+	"github.com/jonas747/yagpdb/stdcommands/editrole"
 	"github.com/jonas747/yagpdb/stdcommands/findserver"
 	"github.com/jonas747/yagpdb/stdcommands/globalrl"
 	"github.com/jonas747/yagpdb/stdcommands/info"
@@ -85,6 +86,7 @@ func (p *Plugin) AddCommands() {
 		simpleembed.Command,
 		currenttime.Command,
 		mentionrole.Command,
+		editrole.Command,
 		listroles.Command,
 		wouldyourather.Command,
 		poll.Command,


### PR DESCRIPTION
A basic utility command to edit role color and some other properties. This is now safe because of the guild-scope-cooldown feature which prevents abuse.

ParseColor also exists in simple-embed so i wonder if it would be a good idea to move it to common.

Have kept cooldown at 15s -- wonder if it should be higher?