### PR TITLE
add .Message as alias to .ReactionMessage

### DIFF
--- a/customcommands/bot.go
+++ b/customcommands/bot.go
@@ -401,6 +401,7 @@ func ExecuteCustomCommandFromReaction(cc *models.CustomCommand, ms *dstate.Membe
 
 	tmplCtx.Data["Reaction"] = reaction
 	tmplCtx.Data["ReactionMessage"] = message
+	tmplCtx.Data["Message"] = message
 	tmplCtx.Data["ReactionAdded"] = added
 
 	return ExecuteCustomCommand(cc, tmplCtx)


### PR DESCRIPTION
Add .Message as alias to .ReactionMessage in reaction commands for consistency across trigger types.