### PR TITLE
BugFix: IsSet bug when carg is "int"

### DIFF
--- a/customcommands/tmplextensions.go
+++ b/customcommands/tmplextensions.go
@@ -131,7 +131,11 @@ func (pa *ParsedArgs) Get(index int) interface{} {
 
 	switch pa.parsed[index].Def.Type.(type) {
 	case *dcmd.IntArg:
-		return pa.parsed[index].Int()
+		i := pa.parsed[index]
+		if i.Value == nil {
+			return nil
+		}
+		return i.Int()
 	case *dcmd.ChannelArg:
 		i := pa.parsed[index].Value
 		if i == nil {


### PR DESCRIPTION
IsSet gives `true` even if argument is not present since .Get returns `0` which is not `nil` in case carg is of type `int`. This should fix it.