### PR TITLE
Add KindOf to StandardFuncMap

### DIFF
--- a/common/templates/context.go
+++ b/common/templates/context.go
@@ -66,6 +66,7 @@ var (
 		"cslice":             CreateSlice,
 		"complexMessage":     CreateMessageSend,
 		"complexMessageEdit": CreateMessageEdit,
+		"kindOf":	      KindOf,
 
 		"formatTime":  tmplFormatTime,
 		"json":        tmplJson,


### PR DESCRIPTION
Fuction was added to general.go but not to context.go