### PR TITLE
Verification (BugFix): Clear Past Scheduled Events

### DIFF
--- a/verification/verification_bot.go
+++ b/verification/verification_bot.go
@@ -153,6 +153,10 @@ func (p *Plugin) startVerificationProcess(conf *models.VerificationConfig, guild
 	}
 
 	// schedule the kick and warnings
+	err = p.clearScheduledEvents(context.Background(), gs.ID, ms.ID) //clear old scheduled events
+	if err != nil {
+		logger.WithError(err).WithField("guild", gs.ID).WithField("user", ms.ID).Error("failed clearing past scheduled warn/kick events.")
+	}
 	if conf.WarnUnverifiedAfter > 0 && conf.WarnMessage != "" {
 		scheduledevents2.ScheduleEvent("verification_user_warn", guildID, time.Now().Add(time.Minute*time.Duration(conf.WarnUnverifiedAfter)), evt)
 	}


### PR DESCRIPTION
Clear past kick/warn scheduled events while setting up new verification process to handle bugs when users rejoin.