### PR TITLE
Fix decoding dicts from DBs

### DIFF
--- a/customcommands/tmplextensions.go
+++ b/customcommands/tmplextensions.go
@@ -644,7 +644,8 @@ type LightDBEntry struct {
 
 func ToLightDBEntry(m *models.TemplatesUserDatabase) (*LightDBEntry, error) {
 	var dst interface{}
-	err := msgpack.Unmarshal(m.ValueRaw, &dst)
+	dec := newDecoder(bytes.NewBuffer(m.ValueRaw))
+	err := dec.Decode(&dst)
 	if err != nil {
 		return nil, err
 	}
@@ -670,6 +671,35 @@ func ToLightDBEntry(m *models.TemplatesUserDatabase) (*LightDBEntry, error) {
 	entry.User.ID = entry.UserID
 
 	return entry, nil
+}
+
+func newDecoder(buf *bytes.Buffer) *msgpack.Decoder {
+	dec := msgpack.NewDecoder(buf)
+
+	dec.SetDecodeMapFunc(func(d *msgpack.Decoder) (interface{}, error) {
+		n, err := d.DecodeMapLen()
+		if err != nil {
+			return nil, err
+		}
+
+		m := make(map[interface{}]interface{}, n)
+		for i := 0; i < n; i++ {
+			mk, err := d.DecodeInterface()
+			if err != nil {
+				return nil, err
+			}
+
+			mv, err := d.DecodeInterface()
+			if err != nil {
+				return nil, err
+			}
+
+			m[mk] = mv
+		}
+		return m, nil
+	})
+
+	return dec
 }
 
 func tmplResultSetToLightDBEntries(ctx *templates.Context, gs *dstate.GuildState, rs []*models.TemplatesUserDatabase) []*LightDBEntry {


### PR DESCRIPTION
Since dicts got a few improvements, there are a few users that are storing them to DBs
Problem is that msgpack, by default, decodes maps as map[string]interface{}... So decoding dicts returns an error
This PR creates a decode that decodes maps as map[interface{}]interface{}

![image](https://user-images.githubusercontent.com/3849946/89114178-f9ff8980-d44f-11ea-90d9-d688e87e21be.png)
