### PR TITLE
Fix new decoder and make json able to marshal interface maps

### DIFF
--- a/common/templates/general.go
+++ b/common/templates/general.go
@@ -878,12 +878,74 @@ func ToByte(from interface{}) []byte {
 }
 
 func tmplJson(v interface{}) (string, error) {
-	b, err := json.Marshal(v)
+	convert := convertMap(v)
+	b, err := json.Marshal(convert)
 	if err != nil {
 		return "", err
 	}
 
 	return string(b), nil
+}
+
+func convertMap(m interface{}) interface{} {
+	out := map[string]interface{}{}
+	val := reflect.ValueOf(m)
+	switch val.Kind() {
+	case reflect.Map:
+		for _, k := range val.MapKeys() {
+			v := val.MapIndex(k)
+			switch t := v.Interface().(type) {
+			case Slice:
+				out[fmt.Sprint(k)] = handleSlices(t, nil)
+			case []interface{}:
+				out[fmt.Sprint(k)] = handleSlices(nil, t)
+			default:
+				out[fmt.Sprint(k)] = convertMap(t)
+			}
+		}
+		return out
+	default:
+		switch t := m.(type) {
+		case Slice:
+			return handleSlices(t, nil)
+		case []interface{}:
+			return handleSlices(nil, t)
+		default:
+			return m
+		}
+	}
+}
+
+func handleSlices(a Slice, b []interface{}) []interface{} {
+	var out []interface{}
+	if a == nil {
+		for _, v := range b {
+			out = append(out, innerHandler(v))
+		}
+	} else {
+		for _, v := range a {
+			out = append(out, innerHandler(v))
+		}
+	}
+
+	return out
+}
+
+func innerHandler(v interface{}) interface{} {
+	val := reflect.ValueOf(v)
+	switch val.Kind() {
+	case reflect.Map:
+		return convertMap(v)
+	case reflect.Slice:
+		switch t := v.(type) {
+		case Slice:
+			return handleSlices(t, nil)
+		case []interface{}:
+			return handleSlices(nil, t)
+		}
+	}
+
+	return v
 }
 
 func tmplFormatTime(t time.Time, args ...string) string {

--- a/customcommands/tmplextensions.go
+++ b/customcommands/tmplextensions.go
@@ -644,13 +644,10 @@ type LightDBEntry struct {
 
 func ToLightDBEntry(m *models.TemplatesUserDatabase) (*LightDBEntry, error) {
 	var dst interface{}
-	err := msgpack.Unmarshal(m.ValueRaw, &dst)
+	dec := newDecoder(bytes.NewBuffer(m.ValueRaw))
+	err := dec.Decode(&dst)
 	if err != nil {
-		dec := newDecoder(bytes.NewBuffer(m.ValueRaw))
-		err = dec.Decode(&dst)
-		if err != nil {
-			return nil, err
-		}
+		return nil, err
 	}
 
 	decodedValue := dst

--- a/customcommands/tmplextensions.go
+++ b/customcommands/tmplextensions.go
@@ -4,7 +4,6 @@ import (
 	"bytes"
 	"context"
 	"database/sql"
-	"fmt"
 	"time"
 
 	"emperror.dev/errors"
@@ -701,9 +700,9 @@ func newDecoder(buf *bytes.Buffer) *msgpack.Decoder {
 			}
 
 			if isStringMap {
-				switch mk.(type) {
+				switch t := mk.(type) {
 				case string:
-					m2[fmt.Sprint(mk)] = mv
+					m2[t] = mv
 				default:
 					isStringMap = false
 				}

--- a/customcommands/tmplextensions.go
+++ b/customcommands/tmplextensions.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"context"
 	"database/sql"
+	"fmt"
 	"time"
 
 	"emperror.dev/errors"
@@ -397,9 +398,9 @@ func tmplDBIncr(ctx *templates.Context) interface{} {
 
 		keyStr := limitString(templates.ToString(key), 256)
 
-		const q = `INSERT INTO templates_user_database (created_at, updated_at, guild_id, user_id, key, value_raw, value_num) 
+		const q = `INSERT INTO templates_user_database (created_at, updated_at, guild_id, user_id, key, value_raw, value_num)
 VALUES ($1, $1, $2, $3, $4, $5, $6)
-ON CONFLICT (guild_id, user_id, key) 
+ON CONFLICT (guild_id, user_id, key)
 DO UPDATE SET value_num = templates_user_database.value_num + $6, updated_at = $1
 RETURNING value_num`
 
@@ -644,10 +645,13 @@ type LightDBEntry struct {
 
 func ToLightDBEntry(m *models.TemplatesUserDatabase) (*LightDBEntry, error) {
 	var dst interface{}
-	dec := newDecoder(bytes.NewBuffer(m.ValueRaw))
-	err := dec.Decode(&dst)
+	err := msgpack.Unmarshal(m.ValueRaw, &dst)
 	if err != nil {
-		return nil, err
+		dec := newDecoder(bytes.NewBuffer(m.ValueRaw))
+		err = dec.Decode(&dst)
+		if err != nil {
+			return nil, err
+		}
 	}
 
 	decodedValue := dst
@@ -683,6 +687,8 @@ func newDecoder(buf *bytes.Buffer) *msgpack.Decoder {
 		}
 
 		m := make(map[interface{}]interface{}, n)
+		m2 := make(map[string]interface{}, n)
+		isStringMap := true
 		for i := 0; i < n; i++ {
 			mk, err := d.DecodeInterface()
 			if err != nil {
@@ -694,8 +700,22 @@ func newDecoder(buf *bytes.Buffer) *msgpack.Decoder {
 				return nil, err
 			}
 
+			if isStringMap {
+				switch mk.(type) {
+				case string:
+					m2[fmt.Sprint(mk)] = mv
+				default:
+					isStringMap = false
+				}
+			}
+
 			m[mk] = mv
 		}
+
+		if isStringMap {
+			return m2, nil
+		}
+
 		return m, nil
 	})
 


### PR DESCRIPTION
Made the custom decoder return `map[string]interface{}` if all keys are strings instead of `map[interface{}]interface{}`.

Made json able to marshal interface maps. 