### PR TITLE
Give users access to regex split

### DIFF
--- a/common/templates/context.go
+++ b/common/templates/context.go
@@ -66,7 +66,7 @@ var (
 		"cslice":             CreateSlice,
 		"complexMessage":     CreateMessageSend,
 		"complexMessageEdit": CreateMessageEdit,
-		"kindOf":	      KindOf,
+		"kindOf":             KindOf,
 
 		"formatTime":  tmplFormatTime,
 		"json":        tmplJson,
@@ -487,7 +487,7 @@ func baseContextFuncs(c *Context) {
 
 	c.ContextFuncs["addRoleID"] = c.tmplAddRoleID
 	c.ContextFuncs["removeRoleID"] = c.tmplRemoveRoleID
-	
+
 	c.ContextFuncs["addRoleName"] = c.tmplAddRoleName
 	c.ContextFuncs["removeRoleName"] = c.tmplRemoveRoleName
 
@@ -520,6 +520,7 @@ func baseContextFuncs(c *Context) {
 	c.ContextFuncs["reFindAll"] = c.reFindAll
 	c.ContextFuncs["reFindAllSubmatches"] = c.reFindAllSubmatches
 	c.ContextFuncs["reReplace"] = c.reReplace
+	c.ContextFuncs["reSplit"] = c.reSplit
 
 	c.ContextFuncs["editChannelTopic"] = c.tmplEditChannelTopic
 	c.ContextFuncs["editChannelName"] = c.tmplEditChannelName
@@ -576,17 +577,17 @@ func MaybeScheduledDeleteMessage(guildID, channelID, messageID int64, delaySecon
 type Dict map[interface{}]interface{}
 
 func (d Dict) Set(key interface{}, value interface{}) string {
-    d[key] = value
-    return ""
+	d[key] = value
+	return ""
 }
 
 func (d Dict) Get(key interface{}) interface{} {
-    return d[key]
+	return d[key]
 }
 
 func (d Dict) Del(key interface{}) string {
-    delete(d, key)
-    return ""
+	delete(d, key)
+	return ""
 }
 
 type SDict map[string]interface{}

--- a/common/templates/context_funcs.go
+++ b/common/templates/context_funcs.go
@@ -1120,6 +1120,15 @@ func (c *Context) reReplace(r string, s string, repl string) (string, error) {
 	return compiled.ReplaceAllString(s, repl), nil
 }
 
+func (c *Context) reSplit(r, s string, i int) ([]string, error) {
+	compiled, err := c.compileRegex(r)
+	if err != nil {
+		return nil, err
+	}
+
+	return compiled.Split(s, i), nil
+}
+
 func (c *Context) tmplEditChannelName(channel interface{}, newName string) (string, error) {
 	if c.IncreaseCheckCallCounter("edit_channel", 10) {
 		return "", ErrTooManyCalls


### PR DESCRIPTION
Create a function called reSplit which is basically regexp.Split