### PR TITLE
command_overrides: reword ignored roles note

### DIFF
--- a/commands/assets/commands.html
+++ b/commands/assets/commands.html
@@ -113,7 +113,7 @@
             </select>
         </div>
         <div class="form-group col-md-6">
-            <label>Ignore users with one of these roles<br><b>Note: Takes priority over required roles.</b></label><br>
+            <label>Ignore users with one of these roles<br><b>Note: Users with an ignored role won't be able to use commands, even if they have a required role.</b></label><br>
             <select multiple="multiple" class="form-control" data-plugin-multiselect name="IgnoreRoles">
                 {{roleOptionsMulti .ActiveGuild.Roles nil .Override.IgnoreRoles}}
             </select>


### PR DESCRIPTION
This PR updates the note below the `ignored roles` section of command overrides. Apparently, some users were confused about the wording of "priority" here, taking it to mean that the roles were required rather than ignored, and this was a common occurrence. 

Wording before and after:
```diff
- Takes priority over required roles.
+ Users with an ignored role won't be able to use commands, even if they have a required role.
```

While this is certainly more verbose, it gets the point across clearly and leaves little room for confusion.