### PR TITLE
 docs(clean): 'clean userId amount' is invalid

### DIFF
--- a/moderation/commands.go
+++ b/moderation/commands.go
@@ -334,7 +334,7 @@ var ModerationCommands = []*commands.YAGCommand{
 		CustomEnabled:   true,
 		CmdCategory:     commands.CategoryModeration,
 		Name:            "Clean",
-		Description:     "Delete the last number of messages from chat, optionally filtering by user, max age and regex or ignoring pinned messages.",
+		Description:     "Delete the last number of messages from chat, optionally filtering by user, max age and regex or ignoring pinned messages.\n⚠️ **Warning:** Using `clean <userId> <amount>` does not work. This is because the user ID is interpreted as the amount. As it is over the limit of 100, it is treated as invalid. You can use `clean <amount> <userId>` instead or mention the user.",
 		LongDescription: "Specify a regex with \"-r regex_here\" and max age with \"-ma 1h10m\"\nNote: Will only look in the last 1k messages",
 		Aliases:         []string{"clear", "cl"},
 		RequiredArgs:    1,


### PR DESCRIPTION
This PR adds a warning to the description of the `clean` command making it clear (excuse the pun) that the combination of `clean userId mention` is invalid. This has been a source of confusion for many in the support server who have encountered the issue, especially as the auto-generated usage implies this combination is valid, when in fact it is not.
> `Clean <User:Mention/ID> <Num:Whole number>`

It is arguable whether this is a good way to resolve the issue - should the code be changed to handle this specific combination instead? In any case, this needs to be fixed or made clear in some way, hence the PR.

Identical to #794, except target branch is actually correct this time 😄 