### PR TITLE
Added random to advices with tags

### DIFF
--- a/stdcommands/advice/advice.go
+++ b/stdcommands/advice/advice.go
@@ -2,6 +2,7 @@ package advice
 
 import (
 	"encoding/json"
+	"math/rand"
 	"net/http"
 	"net/url"
 
@@ -55,7 +56,7 @@ var Command = &commands.YAGCommand{
 		} else {
 			cast := decoded.(*SearchAdviceResp)
 			if len(cast.Slips) > 0 {
-				advice = cast.Slips[0].Advice
+				advice = cast.Slips[rand.Intn(len(cast.Slips))].Advice
 			}
 		}
 


### PR DESCRIPTION
i realised that when using advice with a tag (e.g. `-advice hi` the same advice was always sent even though when using the api there was more than 1 quote returned for the tag of `hi`