### PR TITLE
reminders: allow global deletion of own reminders

### DIFF
--- a/reminders/plugin_bot.go
+++ b/reminders/plugin_bot.go
@@ -111,7 +111,7 @@ var cmds = []*commands.YAGCommand{
 		CmdCategory:  commands.CategoryTool,
 		Name:         "DelReminder",
 		Aliases:      []string{"rmreminder"},
-		Description:  "Deletes a reminder.",
+		Description:  "Deletes a reminder. You can delete reminders from other users provided you are running this command in the same guild the reminder was created in and have the Manage Channel permission in the channel the reminder was created in.",
 		RequiredArgs: 1,
 		Arguments: []*dcmd.ArgDef{
 			{Name: "ID", Type: dcmd.Int},
@@ -127,12 +127,11 @@ var cmds = []*commands.YAGCommand{
 				return "Error retrieving reminder", err
 			}
 
-			if reminder.GuildID != parsed.GS.ID {
-				return "That reminder is not from this server", nil
-			}
-
 			// Check perms
 			if reminder.UserID != discordgo.StrID(parsed.Msg.Author.ID) {
+				if reminder.GuildID != parsed.GS.ID {
+					return "You can only delete reminders that are not your own in the guild the reminder was originally created", nil
+				}
 				ok, err := bot.AdminOrPermMS(reminder.ChannelIDInt(), parsed.MS, discordgo.PermissionManageChannels)
 				if err != nil {
 					return nil, err


### PR DESCRIPTION
**Summary**
Users have often requested to be able to delete their own reminders on guilds other than the guild the reminder was created in. This is usually simply an inconvenience, but can be particularly troublesome if the user has since left the guild / have been removed and cannot run the command on the proper guild.

**Changes**
* Move logic to check whether guild ID is same as reminder guild ID further down in the code
* This allows for users to delete their own reminders even if they aren't in the same server while keeping existing ability to delete others' reminders unchanged
* Improve help message for `DelReminder` to document the fact that reminders made by other users can be deleted given certain criteria are met

* [x] I have tested this on a selfhost and it seems to work fine.