### PR TITLE
Rework ParseDuration

### DIFF
--- a/commands/util.go
+++ b/commands/util.go
@@ -8,7 +8,6 @@ import (
 	"unicode"
 	"unicode/utf8"
 
-	"emperror.dev/errors"
 	"github.com/jonas747/dcmd"
 	"github.com/jonas747/discordgo"
 	"github.com/jonas747/yagpdb/bot"
@@ -30,12 +29,12 @@ func (d *DurationArg) Matches(def *dcmd.ArgDef, part string) bool {
 		return false
 	}
 
-	_, err := ParseDuration(part)
+	_, err := common.ParseDuration(part)
 	return err == nil
 }
 
 func (d *DurationArg) Parse(def *dcmd.ArgDef, part string, data *dcmd.Data) (interface{}, error) {
-	dur, err := ParseDuration(part)
+	dur, err := common.ParseDuration(part)
 	if err != nil {
 		return nil, err
 	}
@@ -53,86 +52,6 @@ func (d *DurationArg) Parse(def *dcmd.ArgDef, part string, data *dcmd.Data) (int
 
 func (d *DurationArg) HelpName() string {
 	return "Duration"
-}
-
-// Parses a time string like 1day3h
-func ParseDuration(str string) (time.Duration, error) {
-	var dur time.Duration
-
-	currentNumBuf := ""
-	currentModifierBuf := ""
-
-	// Parse the time
-	for _, v := range str {
-		// Ignore whitespace
-		if unicode.Is(unicode.White_Space, v) {
-			continue
-		}
-
-		if unicode.IsNumber(v) {
-			// If we reached a number and the modifier was also set, parse the last duration component before starting a new one
-			if currentModifierBuf != "" {
-				if currentNumBuf == "" {
-					currentNumBuf = "1"
-				}
-				d, err := parseDurationComponent(currentNumBuf, currentModifierBuf)
-				if err != nil {
-					return d, err
-				}
-
-				dur += d
-
-				currentNumBuf = ""
-				currentModifierBuf = ""
-			}
-
-			currentNumBuf += string(v)
-
-		} else {
-			currentModifierBuf += string(v)
-		}
-	}
-
-	if currentNumBuf != "" {
-		d, err := parseDurationComponent(currentNumBuf, currentModifierBuf)
-		if err != nil {
-			return dur, errors.WrapIf(err, "not a duration")
-		}
-
-		dur += d
-	}
-
-	return dur, nil
-}
-
-func parseDurationComponent(numStr, modifierStr string) (time.Duration, error) {
-	parsedNum, err := strconv.ParseInt(numStr, 10, 64)
-	if err != nil {
-		return 0, err
-	}
-
-	parsedDur := time.Duration(parsedNum)
-
-	if strings.HasPrefix(modifierStr, "s") {
-		parsedDur = parsedDur * time.Second
-	} else if modifierStr == "" || (strings.HasPrefix(modifierStr, "m") && (len(modifierStr) < 2 || modifierStr[1] != 'o')) {
-		parsedDur = parsedDur * time.Minute
-	} else if strings.HasPrefix(modifierStr, "h") {
-		parsedDur = parsedDur * time.Hour
-	} else if strings.HasPrefix(modifierStr, "d") {
-		parsedDur = parsedDur * time.Hour * 24
-	} else if strings.HasPrefix(modifierStr, "w") {
-		parsedDur = parsedDur * time.Hour * 24 * 7
-	} else if strings.HasPrefix(modifierStr, "mo") {
-		parsedDur = parsedDur * time.Hour * 24 * 30
-	} else if strings.HasPrefix(modifierStr, "y") {
-		parsedDur = parsedDur * time.Hour * 24 * 365
-	} else {
-		return parsedDur, errors.New("couldn't figure out what '" + numStr + modifierStr + "` was")
-	}
-
-	return parsedDur, nil
-
 }
 
 type DurationOutOfRangeError struct {

--- a/common/parseduration.go
+++ b/common/parseduration.go
@@ -1,4 +1,3 @@
-// Code duplicated directly from commands/util.go
 package common
 
 import (
@@ -13,9 +12,7 @@ import (
 // Parses a time string like 1day3h
 func ParseDuration(str string) (time.Duration, error) {
 	var dur time.Duration
-
-	currentNumBuf := ""
-	currentModifierBuf := ""
+	var currentNumBuf, currentModifierBuf string
 
 	// Parse the time
 	for _, v := range str {
@@ -32,7 +29,7 @@ func ParseDuration(str string) (time.Duration, error) {
 				}
 				d, err := parseDurationComponent(currentNumBuf, currentModifierBuf)
 				if err != nil {
-					return d, err
+					return 0, err
 				}
 
 				dur += d
@@ -51,7 +48,7 @@ func ParseDuration(str string) (time.Duration, error) {
 	if currentNumBuf != "" {
 		d, err := parseDurationComponent(currentNumBuf, currentModifierBuf)
 		if err != nil {
-			return dur, errors.WrapIf(err, "not a duration")
+			return 0, errors.WrapIf(err, "not a duration")
 		}
 
 		dur += d
@@ -68,22 +65,23 @@ func parseDurationComponent(numStr, modifierStr string) (time.Duration, error) {
 
 	parsedDur := time.Duration(parsedNum)
 
-	if strings.HasPrefix(modifierStr, "s") {
+	switch {
+	case strings.HasPrefix(modifierStr, "s"):
 		parsedDur = parsedDur * time.Second
-	} else if modifierStr == "" || (strings.HasPrefix(modifierStr, "m") && (len(modifierStr) < 2 || modifierStr[1] != 'o')) {
+	case modifierStr == "", (strings.HasPrefix(modifierStr, "m") && (len(modifierStr) < 2 || modifierStr[1] != 'o')):
 		parsedDur = parsedDur * time.Minute
-	} else if strings.HasPrefix(modifierStr, "h") {
+	case strings.HasPrefix(modifierStr, "h"):
 		parsedDur = parsedDur * time.Hour
-	} else if strings.HasPrefix(modifierStr, "d") {
+	case strings.HasPrefix(modifierStr, "d"):
 		parsedDur = parsedDur * time.Hour * 24
-	} else if strings.HasPrefix(modifierStr, "w") {
+	case strings.HasPrefix(modifierStr, "w"):
 		parsedDur = parsedDur * time.Hour * 24 * 7
-	} else if strings.HasPrefix(modifierStr, "mo") {
+	case strings.HasPrefix(modifierStr, "mo"):
 		parsedDur = parsedDur * time.Hour * 24 * 30
-	} else if strings.HasPrefix(modifierStr, "y") {
+	case strings.HasPrefix(modifierStr, "y"):
 		parsedDur = parsedDur * time.Hour * 24 * 365
-	} else {
-		return parsedDur, errors.New("couldn't figure out what '" + numStr + modifierStr + "` was")
+	default:
+		return 0, errors.New("couldn't figure out what '" + numStr + modifierStr + "` was")
 	}
 
 	return parsedDur, nil

--- a/common/templates/general.go
+++ b/common/templates/general.go
@@ -829,27 +829,16 @@ func ToFloat64(from interface{}) float64 {
 
 func ToDuration(from interface{}) time.Duration {
 	switch t := from.(type) {
-	case int:
-		return time.Duration(int64(t))
-	case int32:
-		return time.Duration(int64(t))
-	case int64:
-		return time.Duration(int64(t))
-	case float32:
-		return time.Duration(int64(t))
-	case float64:
-		return time.Duration(int64(t))
-	case uint:
-		return time.Duration(int64(t))
-	case uint32:
-		return time.Duration(int64(t))
-	case uint64:
-		return time.Duration(int64(t))
+	case int, int32, int64, float32, float64, uint, uint32, uint64:
+		return time.Duration(ToInt64(t))
 	case string:
-		parsed, _ := common.ParseDuration(t)
+		parsed, err := common.ParseDuration(t)
+		if parsed < time.Second || err != nil {
+			return 0
+		}
 		return parsed
 	case time.Duration:
-		return time.Duration(t)
+		return t
 	default:
 		return 0
 	}

--- a/common/util.go
+++ b/common/util.go
@@ -131,8 +131,6 @@ func (d DurationFormatPrecision) FromSeconds(in int64) int64 {
 	}
 
 	panic("We shouldn't be here")
-
-	return 0
 }
 
 func pluralize(val int64) string {


### PR DESCRIPTION
- Removes the `ParseDuration` function from `commands/util` and leave it at `common` only. Since they were duplicated, there was no need to have 2;
- Use `case switching` instead of `else ifs`;
- When there is an error, the function returns `0` instead of `dur`;
- Make `toDuration` check for invalid duration;

Objective: the `ParseDuration` function remains permissive, but it will not return valid if an invalid duration is provided. Also, case switching should make it a little bit faster.

![image](https://user-images.githubusercontent.com/3849946/103461146-e99f5380-4cfa-11eb-950d-529831fe65f9.png)
