### PR TITLE
undelete user switch

### DIFF
--- a/stdcommands/undelete/undelete.go
+++ b/stdcommands/undelete/undelete.go
@@ -19,7 +19,7 @@ var Command = &commands.YAGCommand{
 	RequiredArgs: 0,
 	ArgSwitches: []*dcmd.ArgDef{
 		{Switch: "a", Name: "all"},
-		&dcmd.ArgDef{Switch: "u", Name: "user", Type: dcmd.UserID, Default: 0},
+		{Switch: "u", Name: "user", Type: dcmd.UserID, Default: 0},
 	},
 	RunFunc: func(data *dcmd.Data) (interface{}, error) {
 		allUsers := data.Switch("a").Value != nil && data.Switch("a").Value.(bool)
@@ -36,7 +36,8 @@ var Command = &commands.YAGCommand{
 		}
 		
 		if targetUser != 0 {
-			if ok, err := bot.AdminOrPermMS(data.CS.ID, data.MS, discordgo.PermissionManageMessages); err != nil || !ok && data.MS.ID != targetUser {
+			ok, err := bot.AdminOrPermMS(data.CS.ID, data.MS, discordgo.PermissionManageMessages) 
+			if err != nil || !ok && data.MS.ID != targetUser {
 				if err != nil {
 					return nil, err
 				} else if !ok && data.MS.ID != targetUser {

--- a/stdcommands/undelete/undelete.go
+++ b/stdcommands/undelete/undelete.go
@@ -15,7 +15,8 @@ var Command = &commands.YAGCommand{
 	CmdCategory:  commands.CategoryTool,
 	Name:         "Undelete",
 	Aliases:      []string{"ud"},
-	Description:  "Views the first 10 recent deleted messages. By default only the current users deleted messages will show.\n\nUse `-a` to view all users deleted messages or `-u` to view a specific users deleted messages.\nBoth `-a` and `-u` require \"Manage Messages\" permission.",
+	Description:		"Views the first 10 recent deleted messages. By default, only the current user's deleted messages will show.",
+	LongDescription:  "You can use the `-a` flag to view all users delete messages, or `-u` to view a specified user's deleted messages.\nBoth `-a` and `-u` require Manage Messages permission.\nNote: `-u` overrides `-a` meaning even though `-a` might've been specified along with `-u` only messages from the user provided using `-u` will be shown.",
 	RequiredArgs: 0,
 	ArgSwitches: []*dcmd.ArgDef{
 		{Switch: "a", Name: "all"},
@@ -25,24 +26,14 @@ var Command = &commands.YAGCommand{
 		allUsers := data.Switch("a").Value != nil && data.Switch("a").Value.(bool)
 		targetUser := data.Switch("u").Int64()
 		
-		if allUsers {
-			if ok, err := bot.AdminOrPermMS(data.CS.ID, data.MS, discordgo.PermissionManageMessages); !ok || err != nil {
-				if err != nil {
-					return nil, err
-				} else if !ok {
-					return "You need `Manage Messages` permissions to view all users deleted messages", nil
-				}
-			}
-		}
-		
-		if targetUser != 0 {
-			ok, err := bot.AdminOrPermMS(data.CS.ID, data.MS, discordgo.PermissionManageMessages) 
-			if err != nil || !ok && data.MS.ID != targetUser {
-				if err != nil {
-					return nil, err
-				} else if !ok && data.MS.ID != targetUser {
-					return "You need `Manage Messages` permissions to target a specific user other than yourself.", nil
-				}
+		if allUsers || targetUser != 0 {
+			ok, err := bot.AdminOrPermMS(data.CS.ID, data.MS, discordgo.PermissionManageMessages)
+			if err != nil {
+				return nil, err
+			} else if !ok && targetUser == 0 {
+				return "You need `Manage Messages` permissions to view all users deleted messages", nil
+			} else if !ok {
+				return "You need `Manage Messages` permissions to target a specific user other than yourself.", nil
 			}
 		}
 				

--- a/stdcommands/undelete/undelete.go
+++ b/stdcommands/undelete/undelete.go
@@ -15,7 +15,7 @@ var Command = &commands.YAGCommand{
 	CmdCategory:  commands.CategoryTool,
 	Name:         "Undelete",
 	Aliases:      []string{"ud"},
-	Description:  "Views up to 10 recently deleted messages. By default only the current users deleted messages will show.\n\nUse `-a` to view all users deleted messages or `-u` to view a specific users deleted messages.\nBoth `-a` and `-u` require \"Manage Messages\" permission.",
+	Description:  "Views the first 10 recent deleted messages. By default only the current users deleted messages will show.\n\nUse `-a` to view all users deleted messages or `-u` to view a specific users deleted messages.\nBoth `-a` and `-u` require \"Manage Messages\" permission.",
 	RequiredArgs: 0,
 	ArgSwitches: []*dcmd.ArgDef{
 		{Switch: "a", Name: "all"},


### PR DESCRIPTION
A user in the YAGPDB support server suggested this. Decided to PR it.

All this does is add a new switch to -undelete which is -u that allows you to only show a specific users deleted messages.
`-undelete -u userID/mention`

Edit: Thank you @Pedro-Pessoa and @jo3-l2 for the feedback.