### PR TITLE
Update throwthings.go

### DIFF
--- a/stdcommands/throw/throwthings.go
+++ b/stdcommands/throw/throwthings.go
@@ -44,7 +44,7 @@ var throwThings = []string{
 	"flat earthers",
 	"round earthers",
 	"prequel memes",
-	"logan paul and his dead body",
+	"logan paul and jake paul",
 	"selfbots",
 	"very big fish",
 	"ur mum",


### PR DESCRIPTION
The -throw command is mostly fun, though sometimes confusing when it sends things like: "`b1nzy`", "`jonas747#0001`", `<that long random hash>`, and "`Whitney`".

However, every time it makes a reference to the Suicide Forest, it's decidedly no longer fun. 

This pull request removes the reference to the dead man found in the Suicide Forest, and replaces it with Logan Paul's brother, Jake Paul. 