### PR TITLE
Fix errata on CC's Command trigger description

### DIFF
--- a/customcommands/assets/customcommands-editcmd.html
+++ b/customcommands/assets/customcommands-editcmd.html
@@ -110,7 +110,7 @@
                                             prefix or bot mention followed by the trigger.<br />
                                             For example: If you set the trigger to <code>hello</code> then you can type
                                             <code>-hello</code> or <code>@yagpdb hello</code> to trigger it (assuming
-                                            default default settings)
+                                            default settings)
                                         </p>
                                         <p id="trigger-desc-prefix">
                                             Any message that starts with the trigger will run the command.


### PR DESCRIPTION
Change: `(assuming default default settings)` to `(assuming default settings)`