### PR TITLE
Remove Use Slash Commands permission from invite links

### DIFF
--- a/cmd/yagpdb/templates/cp_nav.html
+++ b/cmd/yagpdb/templates/cp_nav.html
@@ -310,7 +310,7 @@
         {{range $index, $element := .ManagedGuilds -}}{{if not $element.Connected -}}
         <li>
             <a
-                href="https://discordapp.com/oauth2/authorize?client_id={{$clientid}}&scope=applications.commands%20bot&permissions=4294311423&guild_id={{$element.ID}}&response_type=code&redirect_uri={{joinStr "" $baseURL "/manage"}}"><i
+                href="https://discordapp.com/oauth2/authorize?client_id={{$clientid}}&scope=applications.commands%20bot&permissions=2146827775&guild_id={{$element.ID}}&response_type=code&redirect_uri={{joinStr "" $baseURL "/manage"}}"><i
                     class="fas fa-plus"></i>{{$element.Name}}</a>
         </li>
         {{end}}{{end}}

--- a/cmd/yagpdb/templates/index.html
+++ b/cmd/yagpdb/templates/index.html
@@ -54,7 +54,7 @@
           <a class="nav-link" href="/status">Status</a>
         </li>
         <li class="nav-item active">
-          <a class="nav-link" href="https://discordapp.com/oauth2/authorize?client_id={{.ClientID}}&scope=applications.commands%20bot&permissions=4294311423&response_type=code&redirect_uri={{urlquery (joinStr ""  "https://" .Host "/manage")}}">Add to server</a>
+          <a class="nav-link" href="https://discordapp.com/oauth2/authorize?client_id={{.ClientID}}&scope=applications.commands%20bot&permissions=2146827775&response_type=code&redirect_uri={{urlquery (joinStr ""  "https://" .Host "/manage")}}">Add to server</a>
         </li>
         <li class="nav-item active">
           <a class="nav-link" href="/premium">Premium</a>


### PR DESCRIPTION
This effectively reverts a36976d which adds **Use Slash Commands** permission to YAGPDB.xyz's invite links.

I'm highly sure that was a mistake while preparing for Slash Commands. There is no reason bots have **Use Slash Commands** permission. Registering Slash Commands doesn't require that, instead it requires `applications.commands` on authorization that @jonas747 correctly added in c1ee6dd commit. I also don't think bots can use another bot's slash commands via API, and even they could, in most cases it doesn't make sense for bots to use them, and I don't think there is a possibility that features uses them will be added to YAGPDB.xyz.

Since the commit was only added to `master` branch and not to `dev` branch, and this pull request just reverts that, I decided to send it to `master` branch.