### PR TITLE
templates: dbIncr should not increment expired value

### DIFF
--- a/customcommands/tmplextensions.go
+++ b/customcommands/tmplextensions.go
@@ -398,25 +398,29 @@ func tmplDBIncr(ctx *templates.Context) interface{} {
 		keyStr := limitString(templates.ToString(key), 256)
 
 		const q = `INSERT INTO templates_user_database (created_at, updated_at, guild_id, user_id, key, value_raw, value_num) 
-VALUES ($1, $1, $2, $3, $4, $5, $6)
+VALUES (now(), now(), $1, $2, $3, $4, $5)
 ON CONFLICT (guild_id, user_id, key) 
 DO UPDATE SET
 	value_num =
-		CASE
-			WHEN (templates_user_database.expires_at IS NULL OR templates_user_database.expires_at > $1) THEN templates_user_database.value_num + $6
-			-- Entry that has expired
-			ELSE $6
+		-- Don't increment expired entry
+		CASE WHEN (templates_user_database.expires_at IS NULL OR templates_user_database.expires_at > now()) THEN templates_user_database.value_num + $5
+		ELSE $5
 		END,
-	updated_at = $1,
+	updated_at = now(),
+	created_at =
+		-- Reset created_at if the entry expired
+		CASE WHEN (templates_user_database.expires_at IS NULL OR templates_user_database.expires_at > now()) THEN templates_user_database.created_at
+		ELSE now()
+		END,
 	expires_at =
-		CASE
-			WHEN (templates_user_database.expires_at IS NULL OR templates_user_database.expires_at > $1) THEN templates_user_database.expires_at
-			-- Set expiration time to never if the database entry should have expired already
-			ELSE NULL
+		-- Same for expires_at
+		CASE WHEN (templates_user_database.expires_at IS NULL OR templates_user_database.expires_at > now()) THEN templates_user_database.expires_at
+		ELSE NULL
 		END
+	
 RETURNING value_num`
 
-		result := common.PQ.QueryRow(q, time.Now(), ctx.GS.ID, userID, keyStr, valueSerialized, vNum)
+		result := common.PQ.QueryRow(q, ctx.GS.ID, userID, keyStr, valueSerialized, vNum)
 
 		var newVal float64
 		err = result.Scan(&newVal)


### PR DESCRIPTION
Currently, the SQL executed for `dbIncr` does not check whether the entry has expired, causing a bug where it increments the value for an entry which has already expired.

See the following code:
```
{{dbSetExpire 0 "test" 5 10}}
{{sendMessage nil (print (dbIncr 0 "test" 1) " " (dbGet 0 "test").Value)}}
{{sleep 15}}
{{sendMessage nil (print (dbGet 0 "test").Value " " (dbIncr 0 "test" 1))}}
```
This currently results in this:
![image](https://user-images.githubusercontent.com/56809242/114914176-dc543380-9dd6-11eb-9de5-6b7c4e44702c.png)

As seen above, `dbIncr` increments the value of the expired entry from 6 -> 7, instead of treating it as a nonexistent entry and setting the value to 1.

This patch modifies the behavior of `dbIncr` to do this instead, treating the expired entry as nonexistent:
![image](https://user-images.githubusercontent.com/56809242/114914316-00177980-9dd7-11eb-9da8-58838c363ad9.png)
