### PR TITLE
Update Custom Command Default Response

### DIFF
--- a/customcommands/web.go
+++ b/customcommands/web.go
@@ -221,7 +221,7 @@ func handleNewCommand(w http.ResponseWriter, r *http.Request) (web.TemplateData,
 		TimeTriggerExcludingDays:  []int64{},
 		TimeTriggerExcludingHours: []int64{},
 
-		Responses: []string{"Edit this to change the output of the command!"},
+		Responses: []string{"Edit this to change the output of the custom command {{.CCID}}!"},
 	}
 
 	if groupID != 0 {


### PR DESCRIPTION
Seeing as some people still get confused when a random message along of
> Edit this to change the output of the command!

pops up, I thought maybe update it to at least state it is a custom command and what its ID is, so you can find the rogue CC easier. This is my first PR and my first time screwing around with yag's code, so *any* feedback is appreciated.

It now states
> Edit this to change the output of the custom command ##!

Where `##` is the custom command ID.

Thanks in advance!