### PR TITLE
Fix report error

### DIFF
--- a/moderation/commands.go
+++ b/moderation/commands.go
@@ -171,7 +171,7 @@ var ModerationCommands = []*commands.YAGCommand{
 			&dcmd.ArgDef{Name: "User", Type: dcmd.UserID},
 			&dcmd.ArgDef{Name: "Reason", Type: dcmd.String},
 		},
-		
+
 		RunFunc: func(parsed *dcmd.Data) (interface{}, error) {
 			config, _, err := MBaseCmd(parsed, 0) //No need to check member role hierarchy as banned members should not be in server
 			if err != nil {
@@ -185,17 +185,17 @@ var ModerationCommands = []*commands.YAGCommand{
 			}
 			targetID := parsed.Args[0].Int64()
 			target := &discordgo.User{
-					Username:      "unknown",
-					Discriminator: "????",
-					ID:            targetID,
-				  }
+				Username:      "unknown",
+				Discriminator: "????",
+				ID:            targetID,
+			}
 			targetMem, _ := bot.GetMember(parsed.GS.ID, targetID)
 			if targetMem != nil {
 				return "User is not banned!", nil
 			}
 
 			isNotBanned, err := UnbanUser(config, parsed.GS.ID, parsed.Msg.Author, reason, target)
-			
+
 			if err != nil {
 				return nil, err
 			}
@@ -349,6 +349,10 @@ var ModerationCommands = []*commands.YAGCommand{
 
 			target := parsed.Args[0].Int64()
 
+			if target == parsed.Msg.Author.ID {
+				return "You can't report yourself, silly.", nil
+			}
+
 			logLink := CreateLogs(parsed.GS.ID, parsed.CS.ID, parsed.Msg.Author)
 
 			channelID := config.IntReportChannel()
@@ -469,7 +473,7 @@ var ModerationCommands = []*commands.YAGCommand{
 				filtered = true
 			}
 
-                        // Check if we should only delete messages with attachments
+			// Check if we should only delete messages with attachments
 			attachments := false
 			if parsed.Switches["a"].Value != nil && parsed.Switches["a"].Value.(bool) {
 				attachments = true


### PR DESCRIPTION
When trying to report yourself, the bot answers with
```
Something went wrong when running this command, either discord or the bot may be having issues.
```
This pull request fixes that behavior by implementing a check whether the target is equal to the author. If that is the case, the bot will instead respond with 
```
You can't report yourself, silly.
```

This has been tested on a self-hosted instance and works perfectly fine. Additional feedback is, as usual, appreciated.
Thanks in advance!