### PR TITLE
Send response after done resetting rolemenu

### DIFF
--- a/rolecommands/menu.go
+++ b/rolecommands/menu.go
@@ -713,7 +713,7 @@ func cmdFuncRoleMenuResetReactions(data *dcmd.Data) (interface{}, error) {
 		}
 	}
 
-	return nil, nil
+	return "Done resetting rolemenu!", nil
 }
 
 func cmdFuncRoleMenuRemove(data *dcmd.Data) (interface{}, error) {


### PR DESCRIPTION
Not a huge PR, but something that, as I think, will lift some confusion when users reset their rolemenus.
As it stands, yagpdb will not send a message when done with a rolemenu reset.
This pull request changes that, we now send a message:
```
Done resetting rolemenu!
```
Tested it on a self-hosted instance, works like a charm. As usual, feedback is appreciated!
Thanks in advance!