### PR TITLE
Trim whitespaces from prefix

### DIFF
--- a/commands/plugin_web.go
+++ b/commands/plugin_web.go
@@ -185,7 +185,7 @@ func HandleCommands(w http.ResponseWriter, r *http.Request) (web.TemplateData, e
 func HandlePostCommands(w http.ResponseWriter, r *http.Request) (web.TemplateData, error) {
 	ctx := r.Context()
 	activeGuild, templateData := web.GetBaseCPContextData(ctx)
-	newPrefix := strings.TrimLeft(r.FormValue("Prefix"))
+	newPrefix := strings.TrimLeftFunc(r.FormValue("Prefix"), unicode.IsSpace)
 	if len(newPrefix) < 1 || len(newPrefix) > 100 {
 		return templateData, web.NewPublicError("Prefix is smaller than 1 or larger than 100 characters")
 	}

--- a/commands/plugin_web.go
+++ b/commands/plugin_web.go
@@ -185,7 +185,7 @@ func HandleCommands(w http.ResponseWriter, r *http.Request) (web.TemplateData, e
 func HandlePostCommands(w http.ResponseWriter, r *http.Request) (web.TemplateData, error) {
 	ctx := r.Context()
 	activeGuild, templateData := web.GetBaseCPContextData(ctx)
-	newPrefix := strings.TrimSpace(r.FormValue("Prefix"))
+	newPrefix := strings.TrimLeft(r.FormValue("Prefix"))
 	if len(newPrefix) < 1 || len(newPrefix) > 100 {
 		return templateData, web.NewPublicError("Prefix is smaller than 1 or larger than 100 characters")
 	}

--- a/commands/plugin_web.go
+++ b/commands/plugin_web.go
@@ -8,6 +8,7 @@ import (
 	"net/http"
 	"strconv"
 	"strings"
+	"unicode"
 
 	"emperror.dev/errors"
 	"github.com/jonas747/dcmd"

--- a/commands/plugin_web.go
+++ b/commands/plugin_web.go
@@ -7,6 +7,7 @@ import (
 	"html/template"
 	"net/http"
 	"strconv"
+	"strings"
 
 	"emperror.dev/errors"
 	"github.com/jonas747/dcmd"
@@ -184,7 +185,7 @@ func HandleCommands(w http.ResponseWriter, r *http.Request) (web.TemplateData, e
 func HandlePostCommands(w http.ResponseWriter, r *http.Request) (web.TemplateData, error) {
 	ctx := r.Context()
 	activeGuild, templateData := web.GetBaseCPContextData(ctx)
-	newPrefix := r.FormValue("Prefix")
+	newPrefix := strings.TrimSpace(r.FormValue("Prefix"))
 	if len(newPrefix) < 1 || len(newPrefix) > 100 {
 		return templateData, web.NewPublicError("Prefix is smaller than 1 or larger than 100 characters")
 	}


### PR DESCRIPTION
[User suggestion](https://discord.com/channels/166207328570441728/356486960417734666/822955179413995580) on the server, as Discord trims leading whitespaces why not trim whitespaces from the prefix as well.
This will eliminate such a weird prefix as an issue of the bot being unresponsive.

This change trims both leading and trailing whitespaces, however it is easy to change that to only leading whitespaces.
Up to you, but I think both is good.

If I forgot to edit something, please tell me, as far as I could see that is the only function responsible for editing the prefix. Still quite new to Go and yag's code :)