### PR TITLE
moderation: make clear cmd error if missing perms

### DIFF
--- a/moderation/commands.go
+++ b/moderation/commands.go
@@ -403,6 +403,16 @@ var ModerationCommands = []*commands.YAGCommand{
 		},
 		ArgumentCombos: [][]int{[]int{0}, []int{0, 1}, []int{1, 0}},
 		RunFunc: func(parsed *dcmd.Data) (interface{}, error) {
+			botMember, err := bot.GetMember(parsed.Msg.GuildID, common.BotUser.ID)
+			if err != nil {
+				return "Failed fetching bot member to check permissions", nil
+			}
+
+			canClear, err := bot.AdminOrPermMS(parsed.CS.ID, botMember, discordgo.PermissionManageMessages)
+			if err != nil || !canClear {
+				return "I need the `Manage Messages` permission to be able to clear messages", nil
+			}
+
 			config, _, err := MBaseCmd(parsed, 0)
 			if err != nil {
 				return nil, err


### PR DESCRIPTION
Make the `clear` command check for the Manage Messages before executing the rest of the command.
From user suggestion on the server:
> Make yag display an error message when it doesn't have permission to purge messages, rather than saying it deleted a few messages when it actually didn't.

Works fine on selfhost, as far as I can see.