### PR TITLE
cc: add ability to run interval commands from dash

### DIFF
--- a/customcommands/assets/customcommands-editcmd.html
+++ b/customcommands/assets/customcommands-editcmd.html
@@ -361,6 +361,12 @@
                                     formaction="/manage/{{$guild}}/customcommands/commands/{{.CC.LocalID}}/delete">Delete</button>
                             </div>
                         </div>
+                        <div class="row mt-4" id="interval-cc-run-now">
+                            <div class="col">
+                                <button type="submit" class="btn btn-secondary btn-block" title="This will trigger this custom command immediately"
+                                    formaction="/manage/{{$guild}}/customcommands/commands/{{.CC.LocalID}}/run_now">Run now</button>
+                            </div>
+                        </div>
                     </form>
                 </div>
             </div>
@@ -431,6 +437,7 @@
         if (dropdown.val() === "interval_hours" || dropdown.val() === "interval_minutes") {
             // Interval triggers
 
+            $("#interval-cc-run-now").removeClass("hidden")
             $("#cc-time-trigger-details").removeClass("hidden");
 
             $("#cc-text-trigger-details").addClass("hidden");
@@ -448,6 +455,8 @@
             $("#cc-time-trigger-details").addClass("hidden");
             $("#cc-text-trigger-details").addClass("hidden");
 
+            $("#interval-cc-run-now").addClass("hidden")
+
             $("#trigger-warning").attr("hidden", true);
 
         } else if (isTextTrigger(dropdown.val())) {
@@ -458,6 +467,8 @@
 
             $("#cc-reaction-trigger-details").addClass("hidden")
             $("#cc-time-trigger-details").addClass("hidden");
+
+            $("#interval-cc-run-now").addClass("hidden")
 
             $("#trigger-warning").attr("hidden", true);
             // $("#trigger-warning").text("No trigger set, this command will only be able to be called from other commands")
@@ -470,6 +481,7 @@
             $("#cc-reaction-trigger-details").addClass("hidden")
             $("#cc-time-trigger-details").addClass("hidden");
 
+            $("#interval-cc-run-now").addClass("hidden")
 
             $("#trigger-warning").removeAttr("hidden");
             $("#trigger-warning").text("No trigger set, this command will only be able to be called from other commands")

--- a/customcommands/assets/customcommands.html
+++ b/customcommands/assets/customcommands.html
@@ -134,6 +134,8 @@
         <div class="card-header clearfix">
             <form class="form-horizontal" method="post" method="post" action="/manage/{{$guild}}/customcommands/commands/{{.LocalID}}/update" data-async-form>
                 <div class="pull-right">
+                    <button type="submit" class="btn btn-secondary" title="This will trigger this custom command immediately"
+                        formaction="/manage/{{$guild}}/customcommands/commands/{{.LocalID}}/run_now" style="margin: 5px 5px 5px 0px!important">Run now</button>
                     <button type="button" title="#{{.LocalID}} - {{.TextTrigger}}" class="btn btn-success" onclick="window.location.href = '/manage/{{$guild}}/customcommands/commands/{{.LocalID}}/';" style="margin: 5px 5px 5px 0px!important">Edit</button>
                     <button type="submit" title="#{{.LocalID}} - {{.TextTrigger}}" class="btn btn-danger" formaction="/manage/{{$guild}}/customcommands/commands/{{.LocalID}}/delete" style="margin: 5px 5px 5px 0px!important">Delete</button>
                 </div>
@@ -220,7 +222,6 @@
     $('.collapse').on('shown.bs.collapse', function(){
     $(this).parent().find('.cc-collapsibleDown').removeClass('cc-collapsibleDown').addClass('cc-collapsibleUp');}).on('hidden.bs.collapse',function(){
         $(this).parent().find('.cc-collapsibleUp').removeClass('cc-collapsibleUp').addClass('cc-collapsibleDown');});
-    
 </script>
 {{template "cp_footer" .}}
 

--- a/customcommands/assets/customcommands.html
+++ b/customcommands/assets/customcommands.html
@@ -134,10 +134,12 @@
         <div class="card-header clearfix">
             <form class="form-horizontal" method="post" method="post" action="/manage/{{$guild}}/customcommands/commands/{{.LocalID}}/update" data-async-form>
                 <div class="pull-right">
-                    <button type="submit" class="btn btn-secondary" title="This will trigger this custom command immediately"
-                        formaction="/manage/{{$guild}}/customcommands/commands/{{.LocalID}}/run_now" style="margin: 5px 5px 5px 0px!important">Run now</button>
                     <button type="button" title="#{{.LocalID}} - {{.TextTrigger}}" class="btn btn-success" onclick="window.location.href = '/manage/{{$guild}}/customcommands/commands/{{.LocalID}}/';" style="margin: 5px 5px 5px 0px!important">Edit</button>
                     <button type="submit" title="#{{.LocalID}} - {{.TextTrigger}}" class="btn btn-danger" formaction="/manage/{{$guild}}/customcommands/commands/{{.LocalID}}/delete" style="margin: 5px 5px 5px 0px!important">Delete</button>
+                    {{if eq .TriggerType 5}}
+                        <button type="submit" class="btn btn-secondary" title="This will trigger this custom command immediately"
+                        formaction="/manage/{{$guild}}/customcommands/commands/{{.LocalID}}/run_now" style="margin: 5px 5px 5px 0px!important">Run now</button>
+                    {{end}}
                 </div>
             </form>
             <h2 class="card-title">

--- a/customcommands/bot.go
+++ b/customcommands/bot.go
@@ -37,6 +37,7 @@ import (
 	"github.com/jonas747/yagpdb/stdcommands/util"
 	"github.com/sirupsen/logrus"
 	"github.com/vmihailenco/msgpack"
+	"github.com/volatiletech/null"
 	"github.com/volatiletech/sqlboiler/queries/qm"
 )
 
@@ -75,9 +76,41 @@ func (p *Plugin) BotInit() {
 
 		gs.UserCacheDel(CacheKeyCommands)
 	}, nil)
+	pubsub.AddHandler("custom_commands_run_now", handleCustomCommandsRunNow, models.CustomCommand{})
 
 	scheduledevents2.RegisterHandler("cc_next_run", NextRunScheduledEvent{}, handleNextRunScheduledEVent)
 	scheduledevents2.RegisterHandler("cc_delayed_run", DelayedRunCCData{}, handleDelayedRunCC)
+}
+
+func handleCustomCommandsRunNow(event *pubsub.Event) {
+	dataCast := event.Data.(*models.CustomCommand)
+	f := logger.WithFields(logrus.Fields{
+		"guild_id": dataCast.GuildID,
+		"cmd_id":   dataCast.LocalID,
+	})
+
+	gs := bot.State.Guild(true, dataCast.GuildID)
+	if gs == nil {
+		f.Error("failed fetching active guild from state")
+		return
+	}
+
+	cs := gs.Channel(true, dataCast.ContextChannel)
+	if cs == nil {
+		f.Error("failed finding channel to run cc in")
+		return
+	}
+
+	metricsExecutedCommands.With(prometheus.Labels{"trigger": "timed"}).Inc()
+
+	tmplCtx := templates.NewContext(gs, cs, nil)
+	ExecuteCustomCommand(dataCast, tmplCtx)
+
+	dataCast.LastRun = null.TimeFrom(time.Now())
+	err := UpdateCommandNextRunTime(dataCast, true, true)
+	if err != nil {
+		f.WithError(err).Error("failed updating custom command next run time")
+	}
 }
 
 type DelayedRunCCData struct {

--- a/customcommands/web.go
+++ b/customcommands/web.go
@@ -9,13 +9,18 @@ import (
 	"strings"
 	"unicode/utf8"
 
+	"github.com/mediocregopher/radix/v3"
+	"github.com/prometheus/client_golang/prometheus"
 	"github.com/volatiletech/null"
 
 	"emperror.dev/errors"
+	"github.com/jonas747/discordgo"
+	"github.com/jonas747/yagpdb/bot"
 	"github.com/jonas747/yagpdb/common"
 	"github.com/jonas747/yagpdb/common/cplogs"
 	"github.com/jonas747/yagpdb/common/featureflags"
 	"github.com/jonas747/yagpdb/common/pubsub"
+	"github.com/jonas747/yagpdb/common/templates"
 	yagtemplate "github.com/jonas747/yagpdb/common/templates"
 	"github.com/jonas747/yagpdb/customcommands/models"
 	"github.com/jonas747/yagpdb/web"
@@ -90,6 +95,7 @@ func (p *Plugin) InitWeb() {
 	subMux.Handle(pat.Post("/commands/new"), newCommandHandler)
 	subMux.Handle(pat.Post("/commands/:cmd/update"), web.ControllerPostHandler(handleUpdateCommand, getCmdHandler, CustomCommand{}))
 	subMux.Handle(pat.Post("/commands/:cmd/delete"), web.ControllerPostHandler(handleDeleteCommand, getHandler, nil))
+	subMux.Handle(pat.Post("/commands/:cmd/run_now"), web.ControllerPostHandler(handleRunCommandNow, getCmdHandler, nil))
 
 	subMux.Handle(pat.Post("/creategroup"), web.ControllerPostHandler(handleNewGroup, getHandler, GroupForm{}))
 	subMux.Handle(pat.Post("/groups/:group/update"), web.ControllerPostHandler(handleUpdateGroup, getGroupHandler, GroupForm{}))
@@ -339,6 +345,78 @@ func handleDeleteCommand(w http.ResponseWriter, r *http.Request) (web.TemplateDa
 	featureflags.MarkGuildDirty(activeGuild.ID)
 	common.LogIgnoreError(pubsub.Publish("custom_commands_clear_cache", activeGuild.ID, nil), "failed creating pubsub cache eviction event", web.CtxLogger(ctx).Data)
 	return templateData, err
+}
+
+const RunCmdCooldownSeconds = 5
+
+func keyRunCmdCooldown(guildID, userID int64) string {
+	return "custom_command_run_now_cooldown:" + discordgo.StrID(guildID) + ":" + discordgo.StrID(userID)
+}
+
+func checkSetCooldown(guildID, userID int64) (bool, error) {
+	var resp string
+	err := common.RedisPool.Do(radix.FlatCmd(&resp, "SET", keyRunCmdCooldown(guildID, userID), true, "EX", RunCmdCooldownSeconds, "NX"))
+	if err != nil {
+		return false, err
+	}
+
+	return resp == "OK", nil
+}
+
+func handleRunCommandNow(w http.ResponseWriter, r *http.Request) (web.TemplateData, error) {
+	ctx := r.Context()
+	activeGuild, templateData := web.GetBaseCPContextData(ctx)
+	member := web.ContextMember(ctx)
+	if member == nil {
+		templateData.AddAlerts()
+		return templateData, nil
+	}
+
+	cmdID, err := strconv.ParseInt(pat.Param(r, "cmd"), 10, 64)
+	if err != nil {
+		return templateData, err
+	}
+
+	// only interval commands can be ran from the dashboard currently
+	cmd, err := models.CustomCommands(qm.Where("guild_id = ? AND local_id = ? AND trigger_type = 5", activeGuild.ID, cmdID)).OneG(context.Background())
+	if err != nil {
+		return templateData, err
+	}
+
+	ok, err := checkSetCooldown(activeGuild.ID, member.User.ID)
+	if err != nil {
+		return templateData, err
+	}
+
+	if !ok {
+		templateData.AddAlerts(web.ErrorAlert("You're on cooldown, wait before trying again"))
+		return templateData, nil
+	}
+
+	gs := bot.State.Guild(true, activeGuild.ID)
+	if gs == nil {
+		templateData.AddAlerts(web.ErrorAlert("Failed fetching active guild from state, try again"))
+		return templateData, nil
+	}
+
+	cs := gs.Channel(true, cmd.ContextChannel)
+	if cs == nil {
+		templateData.AddAlerts(web.ErrorAlert("Failed finding channel to run CC in, try again"))
+		return templateData, nil
+	}
+
+	metricsExecutedCommands.With(prometheus.Labels{"trigger": "timed"}).Inc()
+
+	tmplCtx := templates.NewContext(gs, cs, nil)
+	ExecuteCustomCommand(cmd, tmplCtx)
+
+	cmd.LastRun = cmd.NextRun
+	err = UpdateCommandNextRunTime(cmd, true, false)
+	if err != nil {
+		web.CtxLogger(ctx).WithError(err).Error("failed updating custom command next run time")
+	}
+
+	return templateData, nil
 }
 
 // allow for max 5 triggers with intervals of less than 10 minutes

--- a/customcommands/web.go
+++ b/customcommands/web.go
@@ -7,6 +7,7 @@ import (
 	"net/http"
 	"strconv"
 	"strings"
+	"time"
 	"unicode/utf8"
 
 	"github.com/mediocregopher/radix/v3"
@@ -410,7 +411,7 @@ func handleRunCommandNow(w http.ResponseWriter, r *http.Request) (web.TemplateDa
 	tmplCtx := templates.NewContext(gs, cs, nil)
 	ExecuteCustomCommand(cmd, tmplCtx)
 
-	cmd.LastRun = cmd.NextRun
+	cmd.LastRun = null.TimeFrom(time.Now())
 	err = UpdateCommandNextRunTime(cmd, true, false)
 	if err != nil {
 		web.CtxLogger(ctx).WithError(err).Error("failed updating custom command next run time")


### PR DESCRIPTION
This adds the ability to run interval CCs immediately from the dashboard, as title states.
Mostly useful for testing (no need to wait for it to trigger / put it into another CC).
To prevent spam, there is a 5s cooldown -- let me know if you want this changed.

![Image of main CC listing](https://user-images.githubusercontent.com/56809242/117099289-a3e4ad00-ad25-11eb-96e8-f4c4a8ea4fdb.png)
![Image of edit CC view](https://user-images.githubusercontent.com/56809242/117099429-02aa2680-ad26-11eb-869a-58cef6422cd6.png)
Second one looks particularly ugly but I couldn't find a better place to put it, suggestions are appreciated.
