### PR TITLE
commands: display cmd usage, warn for trailing space in prefix

### DIFF
--- a/cmd/yagpdb/static/js/spongebob.js
+++ b/cmd/yagpdb/static/js/spongebob.js
@@ -231,8 +231,10 @@ function updateSelectedMenuItem(pathname) {
 	}
 }
 
-function addAlert(kind, msg) {
-	$("<div/>").addClass("row").append(
+function addAlert(kind, msg, id) {
+	const alert = $(`<div/>`);
+	if (id !== undefined) alert.prop("id", id)
+	alert.addClass("row").append(
 		$("<div/>").addClass("col-lg-12").append(
 			$("<div/>").addClass("alert alert-" + kind).text(msg)
 		)

--- a/commands/assets/commands.html
+++ b/commands/assets/commands.html
@@ -30,6 +30,9 @@
                             <div class="col-lg-6">
                                 <div class="form-group">
                                     <label for="prefix">Command Prefix</label>
+                                    <div class="row-lg-6">
+                                        <p id="example-command-usage">Example command usage: <code>{{.CommandPrefix}}ping</code></p>
+                                    </div>
                                     <input type="text" class="form-control" id="prefix" name="Prefix"
                                         value="{{.CommandPrefix}}">
                                 </div>
@@ -74,6 +77,23 @@
     <!-- /.col-lg-12 -->
 </div>
 <!-- /.row -->
+
+<script>
+    $("#prefix").keyup(function() {
+        const prefix = $(this).val();
+        if (prefix.length === 0) return;
+
+        $("#example-command-usage > code").text(`${prefix}ping`);
+
+        const existingWarning = $("#trailing-space-warning");
+        if (prefix[prefix.length - 1] === " ") {
+            if (existingWarning.length > 0) return; // don't duplicate warnings
+            addAlert("warning", `You have a trailing space in your command prefix, meaning that while '${prefix}ping' would trigger, '${prefix.trimRight()}ping' would not.`, "trailing-space-warning")
+        } else if (existingWarning.length) {
+            existingWarning.remove();
+        }
+    });
+</script>
 
 {{template "cp_footer" .}}
 


### PR DESCRIPTION
Continuation of #884.

First, this pull request adds a preview of an example command using the prefix inputted by the user, updated live when they change the prefix. This is meant to help users who are confused about what exactly the prefix does (some in help channels have set the prefix to command names like `-rolemenu create`) by showing them an example usage of a command.

Secondly, it adds a warning box if the prefix has trailing spaces. While, as mentioned in the previous issue, there are legitimate uses for such a thing to occur, if it is indeed a mistake it can be very hard for volunteers to spot or solve (space is essentially invisible). As such, I felt a warning box would be appropriate here.

![Image of new prefix interface](https://user-images.githubusercontent.com/56809242/117398236-cfe16900-aeb2-11eb-8c8f-40b973c60163.png)
