### PR TITLE
docker: rm outdated image, speedup build

### DIFF
--- a/yagpdb_docker/Dockerfile
+++ b/yagpdb_docker/Dockerfile
@@ -1,7 +1,13 @@
 FROM golang:stretch as builder
 
-# Uncomment during development
-COPY . /appbuild/yagpdb
+WORKDIR /appbuild/yagpdb/
+
+COPY go.mod .
+COPY go.sum .
+
+RUN go mod download
+
+COPY . .
 
 WORKDIR /appbuild/yagpdb/cmd/yagpdb
 
@@ -15,7 +21,9 @@ VOLUME /app/soundboard \
 EXPOSE 80 443
 
 # We need the X.509 certificates for client TLS to work.
-RUN apk --no-cache add ca-certificates
+# Also install tzdata, needed for Go timezone support, as the alpine image does
+# not come with it by default. 
+RUN apk --no-cache add ca-certificates tzdata
 
 # Add ffmpeg for soundboard support
 RUN apk --no-cache add ffmpeg

--- a/yagpdb_docker/docker-compose.yml
+++ b/yagpdb_docker/docker-compose.yml
@@ -11,7 +11,12 @@ networks:
 
 services:
   app:
-    image: caskd/yagpdb
+    # We don't provide an official image, but there is a community-made image you can try:
+    #  - teyker/yagpdb (https://hub.docker.com/r/teyker/yagpdb)
+    #
+    # Note that we do not take responsibility for anything that happens as a result of using
+    # the image above.
+    image: PUT_YOUR_OWN_IMAGE_HERE
     restart: unless-stopped
     command:
       - "-all"


### PR DESCRIPTION
See individual commit descriptions for more detail, but essentially:

1. Speed up build by making use of the implicit image cache better -- instead of always reinstalling modules from scratch, it'll now only do it when either `go.mod` or `go.sum` have changed. This results in a near 2x speedup on my machine -- the first run is nearly the same at around a minute (since it has to install modules anyways) but when it can use the cache the build time halves to around 30s.
2. `caskd/yagpdb` has been outdated for over a year now, recommending it for use in the default Compose file only causes confusion (known bugs are still not fixed on their instance, many new features are missing, etc.). Most users who are using a prebuilt image are now using `teyker/yagpdb`, a community image. I did not change that to the default image out of an abundance of caution but I can do it if you'd like to.