### PR TITLE
slashcommands: add missing strings.ToLower()

### DIFF
--- a/commands/slashcommands.go
+++ b/commands/slashcommands.go
@@ -196,7 +196,7 @@ func (yc *YAGCommand) slashCommandOptions() (turnedIntoSubCommands bool, result 
 
 				subCommands = append(subCommands, &discordgo.ApplicationCommandOption{
 					Kind:        kind,
-					Name:        "by-" + opt.Name,
+					Name:        "by-" + strings.ToLower(opt.Name),
 					Description: common.CutStringShort(yc.Description, 100),
 					Options: []*discordgo.ApplicationCommandOption{
 						opt,


### PR DESCRIPTION
Looks like this was missed in https://github.com/jonas747/yagpdb/commit/2e09ee17ecf2dac1527acb8b00c1451f1ae62b6e.