### PR TITLE
moderation: support anonymous reports

### DIFF
--- a/moderation/assets/moderation.html
+++ b/moderation/assets/moderation.html
@@ -123,12 +123,14 @@ the punishment{{end}}
         </div>
         <hr />
 
-        {{checkbox "ReportEnabled" "report-enabled" "Enable report command?" .ModConfig.ReportEnabled}}
+        {{checkbox "ReportEnabled" "report-enabled" "Enable report and reporter commands?" .ModConfig.ReportEnabled}}
         <p><code>(mention or prefix) report @user some reason</code><br />
             Everyone can use this.<br />
             Report will upload a log of the last 100 messages in the channel and send a message about it in the
             report channel.
         </p>
+        {{checkbox "AnonymousReports" "anonymous-reports" "Make reports anonymous by default" .ModConfig.AnonymousReports}}
+        <p>Users with the Manage Messages permission will be able to view whoever created a report using the <code>(mention or prefix)reporter report-id</code> command.</p>
         <hr />
 
         {{checkbox "LogUnbans" "log-unbans" "Log unban events in the modlog channel" .ModConfig.LogUnbans}}

--- a/moderation/models.go
+++ b/moderation/models.go
@@ -24,11 +24,11 @@ type Config struct {
 	KickMessage          string `valid:"template,5000"`
 
 	// Ban
-	BanEnabled        	bool
-	BanCmdRoles       	pq.Int64Array `gorm:"type:bigint[]" valid:"role,true"`
-	BanReasonOptional 	bool
-	BanMessage        	string `valid:"template,5000"`
-	DefaultBanDeleteDays    sql.NullInt64 `gorm:"default:1" valid:"0,7"`
+	BanEnabled           bool
+	BanCmdRoles          pq.Int64Array `gorm:"type:bigint[]" valid:"role,true"`
+	BanReasonOptional    bool
+	BanMessage           string        `valid:"template,5000"`
+	DefaultBanDeleteDays sql.NullInt64 `gorm:"default:1" valid:"0,7"`
 
 	// Mute/unmute
 	MuteEnabled             bool
@@ -52,12 +52,13 @@ type Config struct {
 	WarnMessage            string `valid:"template,5000"`
 
 	// Misc
-	CleanEnabled  bool
-	ReportEnabled bool
-	ActionChannel string `valid:"channel,true"`
-	ReportChannel string `valid:"channel,true"`
-	LogUnbans     bool
-	LogBans       bool
+	CleanEnabled     bool
+	ReportEnabled    bool
+	AnonymousReports bool   `gorm:"default:false"`
+	ActionChannel    string `valid:"channel,true"`
+	ReportChannel    string `valid:"channel,true"`
+	LogUnbans        bool
+	LogBans          bool
 
 	GiveRoleCmdEnabled bool
 	GiveRoleCmdModlog  bool
@@ -100,6 +101,16 @@ func (c *Config) Save(guildID int64) error {
 
 	pubsub.Publish("mod_refresh_mute_override", guildID, nil)
 	return err
+}
+
+type ReportModel struct {
+	common.SmallModel
+	ReporterID                 int64
+	ReporterUsernameAndDiscrim string
+}
+
+func (r *ReportModel) TableName() string {
+	return "moderation_reports"
 }
 
 type WarningModel struct {

--- a/moderation/moderation.go
+++ b/moderation/moderation.go
@@ -52,7 +52,7 @@ func RegisterPlugin() {
 	common.RegisterPlugin(plugin)
 
 	configstore.RegisterConfig(configstore.SQL, &Config{})
-	common.GORM.AutoMigrate(&Config{}, &WarningModel{}, &MuteModel{})
+	common.GORM.AutoMigrate(&Config{}, &WarningModel{}, &MuteModel{}, &ReportModel{})
 }
 
 func getConfigIfNotSet(guildID int64, config *Config) (*Config, error) {


### PR DESCRIPTION
This PR adds support for *anonymous reports*, where the reporter's name is hidden in the mod log message (but is still retrievable by staff). It's mostly useful for servers with public mod-logs where the accused user may start an unwanted argument with those who reported them.