### PR TITLE
Dockerfile: Add versioning and reduce image layer count

### DIFF
--- a/yagpdb_docker/Dockerfile
+++ b/yagpdb_docker/Dockerfile
@@ -11,7 +11,7 @@ COPY . .
 
 WORKDIR /appbuild/yagpdb/cmd/yagpdb
 
-RUN CGO_ENABLED=0 GOOS=linux go build -v
+RUN CGO_ENABLED=0 GOOS=linux go build -ldflags "-X github.com/jonas747/yagpdb/common.VERSION=$(git describe --tags)" -v
 
 FROM alpine:latest
 

--- a/yagpdb_docker/Dockerfile
+++ b/yagpdb_docker/Dockerfile
@@ -21,12 +21,12 @@ VOLUME /app/soundboard \
 EXPOSE 80 443
 
 # We need the X.509 certificates for client TLS to work.
-# Also install tzdata, needed for Go timezone support, as the alpine image does
-# not come with it by default. 
-RUN apk --no-cache add ca-certificates tzdata
-
-# Add ffmpeg for soundboard support
-RUN apk --no-cache add ffmpeg
+# Also install tzdata, needed for Go timezone support, 
+# and ffmpeg for soundboard support,
+# as the alpine image does not come with them by default. 
+RUN apk --no-cache add ca-certificates \
+  ffmpeg \
+  tzdata
 
 # Handle templates for plugins automatically
 COPY --from=builder /appbuild/yagpdb/*/assets/*.html templates/plugins/


### PR DESCRIPTION
Added the ldflags from build.sh to the Dockerfile in order to add versioning and resolve the "YAGPDB Status, version unknown" status message.

Combined RUN statements to minimize the number of image layers.
Best practice according to https://docs.docker.com/develop/develop-images/dockerfile_best-practices/
