### PR TITLE
revert: recover from panics in templates

### DIFF
--- a/common/templates/context.go
+++ b/common/templates/context.go
@@ -283,13 +283,7 @@ func (c *Context) Execute(source string) (string, error) {
 	return c.executeParsed()
 }
 
-func (c *Context) executeParsed() (r string, err error) {
-	defer func() {
-		if r := recover(); r != nil {
-			err = errors.New("paniced!")
-		}
-	}()
-
+func (c *Context) executeParsed() (string, error) {
 	parsed := c.CurrentFrame.parsedTemplate
 	if c.IsPremium {
 		parsed = parsed.MaxOps(MaxOpsPremium)
@@ -301,7 +295,7 @@ func (c *Context) executeParsed() (r string, err error) {
 	w := LimitWriter(&buf, 25000)
 
 	// started := time.Now()
-	err = parsed.Execute(w, c.Data)
+	err := parsed.Execute(w, c.Data)
 
 	// dur := time.Since(started)
 	if c.FixedOutput != "" {


### PR DESCRIPTION
This reverts commit 0593808669143735cf2d88d014fa072e5239e71a.

There is already code in place to recover from panics during template execution (and panics in general) further up in the code hierarchy. As such, this change was unneeded and was actually counterproductive - it resulted in a variety of errors regressing from a clear error message to the rather unhelpful `paniced` error.