### PR TITLE
templates: Fix DM template bugs

### DIFF
--- a/common/templates/context.go
+++ b/common/templates/context.go
@@ -139,6 +139,8 @@ type Context struct {
 
 	CurrentFrame *contextFrame
 
+	IsExecedByLeaveMessage bool
+
 	contextFuncsAdded bool
 }
 
@@ -289,6 +291,10 @@ func (c *Context) executeParsed() (r string, err error) {
 			err = errors.New("paniced!")
 		}
 	}()
+
+	if c.CurrentFrame.SendResponseInDM && c.IsExecedByLeaveMessage {
+		return "", errors.New("cannot send DM on leave message")
+	}
 
 	parsed := c.CurrentFrame.parsedTemplate
 	if c.IsPremium {

--- a/customcommands/bot.go
+++ b/customcommands/bot.go
@@ -89,6 +89,8 @@ type DelayedRunCCData struct {
 	Member  *dstate.MemberState
 
 	UserKey interface{} `json:"user_key"`
+
+	IsExecedByLeaveMessage bool `json:"is_execed_by_leave_message"`
 }
 
 var cmdListCommands = &commands.YAGCommand{
@@ -96,7 +98,7 @@ var cmdListCommands = &commands.YAGCommand{
 	Name:           "CustomCommands",
 	Aliases:        []string{"cc"},
 	Description:    "Shows a custom command specified by id or trigger, or lists them all",
-	ArgumentCombos: [][]int{[]int{0}, []int{1}, []int{}},
+	ArgumentCombos: [][]int{{0}, {1}, {}},
 	Arguments: []*dcmd.ArgDef{
 		{Name: "ID", Type: dcmd.Int},
 		{Name: "Trigger", Type: dcmd.String},
@@ -287,6 +289,8 @@ func handleDelayedRunCC(evt *schEventsModels.ScheduledEvent, data interface{}) (
 		tmplCtx.Msg = dataCast.Message
 		tmplCtx.Data["Message"] = dataCast.Message
 	}
+
+	tmplCtx.IsExecedByLeaveMessage = dataCast.IsExecedByLeaveMessage
 
 	// decode userdata
 	if len(dataCast.UserData) > 0 {

--- a/customcommands/tmplextensions.go
+++ b/customcommands/tmplextensions.go
@@ -212,6 +212,7 @@ func tmplRunCC(ctx *templates.Context) interface{} {
 			}
 			newCtx.Data["ExecData"] = data
 			newCtx.Data["StackDepth"] = currentStackDepth + 1
+			newCtx.IsExecedByLeaveMessage = ctx.IsExecedByLeaveMessage
 
 			go ExecuteCustomCommand(cmd, newCtx)
 			return "", nil
@@ -223,6 +224,8 @@ func tmplRunCC(ctx *templates.Context) interface{} {
 
 			Member:  ctx.MS,
 			Message: ctx.Msg,
+
+			IsExecedByLeaveMessage: ctx.IsExecedByLeaveMessage,
 		}
 
 		// embed data using msgpack to include type information
@@ -284,6 +287,8 @@ func tmplScheduleUniqueCC(ctx *templates.Context) interface{} {
 			Member:  ctx.MS,
 			Message: ctx.Msg,
 			UserKey: stringedKey,
+
+			IsExecedByLeaveMessage: ctx.IsExecedByLeaveMessage,
 		}
 
 		// embed data using msgpack to include type information

--- a/notifications/plugin_bot.go
+++ b/notifications/plugin_bot.go
@@ -125,6 +125,7 @@ func HandleGuildMemberRemove(evt *eventsystem.EventData) (retry bool, err error)
 func sendTemplate(cs *dstate.ChannelState, tmpl string, ms *dstate.MemberState, name string, censorInvites bool, enableSendDM bool) bool {
 	ctx := templates.NewContext(cs.Guild, cs, ms)
 	ctx.CurrentFrame.SendResponseInDM = cs.Type == discordgo.ChannelTypeDM
+	ctx.IsExecedByLeaveMessage = !enableSendDM
 
 	ctx.Data["RealUsername"] = ms.Username
 	if censorInvites {

--- a/stdcommands/howlongtobeat/howlongtobeat.go
+++ b/stdcommands/howlongtobeat/howlongtobeat.go
@@ -1,0 +1,147 @@
+package howlongtobeat
+
+import (
+	"fmt"
+	"math/rand"
+	"sort"
+	"strings"
+
+	"github.com/jonas747/dcmd/v2"
+	"github.com/jonas747/discordgo"
+	"github.com/jonas747/yagpdb/bot/paginatedmessages"
+	"github.com/jonas747/yagpdb/commands"
+)
+
+type hltb struct {
+	GameTitle     string
+	PureTitle     string //useful for Levenshtein calculation, symbol clutter removed
+	GameURL       string
+	ImageURL      string
+	MainStory     []string
+	MainExtra     []string
+	Completionist []string
+	LevDistance   int
+	LevSimilarity float64
+	OnlineGame    bool
+}
+
+var (
+	hltbScheme   = "https"
+	hltbHost     = "howlongtobeat.com"
+	hltbURL      = fmt.Sprintf("%s://%s/", hltbScheme, hltbHost)
+	hltbHostPath = "search_results.php"
+	hltbRawQuery = "page=1"
+)
+
+//Command var needs a comment for lint :)
+var Command = &commands.YAGCommand{
+	CmdCategory:  commands.CategoryFun,
+	Name:         "HowLongToBeat",
+	Aliases:      []string{"hltb"},
+	RequiredArgs: 1,
+	Description:  "Game information based on query from howlongtobeat.com.\nResults are sorted by popularity, it's their default. Without -p returns the first result.\nSwitch -p gives paginated output using Levenshtein distance sorting max 20 results.",
+	DefaultEnabled:      true,
+	SlashCommandEnabled: true,
+	Arguments: []*dcmd.ArgDef{
+		{Name: "Game-Title", Type: dcmd.String},
+	},
+	ArgSwitches: []*dcmd.ArgDef{
+		{Name: "c", Help: "Compact output"},
+		{Name: "p", Help: "Paginated output"},
+	},
+	RunFunc: func(data *dcmd.Data) (interface{}, error) {
+		var compactView, paginatedView bool
+		gameName := data.Args[0].Str()
+
+		if data.Switches["c"].Value != nil && data.Switches["c"].Value.(bool) {
+			compactView = true
+		}
+
+		if data.Switches["p"].Value != nil && data.Switches["p"].Value.(bool) {
+			compactView = false
+			paginatedView = true
+		}
+
+		getData, err := getGameData(gameName)
+		if err != nil {
+			return nil, err
+		}
+		toReader := strings.NewReader(getData)
+
+		hltbQuery, err := parseGameData(gameName, toReader)
+		if err != nil {
+			return nil, err
+		}
+
+		if hltbQuery[0].GameTitle == "" {
+			return "No results", nil
+		}
+
+		if compactView {
+			compactData := fmt.Sprintf("%s: %s | %s | %s | <%s>",
+				normaliseTitle(hltbQuery[0].GameTitle),
+				strings.Trim(fmt.Sprint(hltbQuery[0].MainStory), "[]"),
+				strings.Trim(fmt.Sprint(hltbQuery[0].MainExtra), "[]"),
+				strings.Trim(fmt.Sprint(hltbQuery[0].Completionist), "[]"),
+				hltbQuery[0].GameURL)
+			return compactData, nil
+		}
+
+		hltbEmbed := embedCreator(hltbQuery, 0, paginatedView)
+
+		if paginatedView {
+			_, err := paginatedmessages.CreatePaginatedMessage(
+				data.GuildData.GS.ID, data.ChannelID, 1, len(hltbQuery), func(p *paginatedmessages.PaginatedMessage, page int) (*discordgo.MessageEmbed, error) {
+					i := page - 1
+					sort.SliceStable(hltbQuery, func(i, j int) bool {
+						return hltbQuery[i].LevDistance < hltbQuery[j].LevDistance
+					})
+					paginatedEmbed := embedCreator(hltbQuery, i, paginatedView)
+					return paginatedEmbed, nil
+				})
+			if err != nil {
+				return "Something went wrong", nil
+			}
+		} else {
+			return hltbEmbed, nil
+		}
+
+		return nil, nil
+	},
+}
+
+func embedCreator(hltbQuery []hltb, i int, paginated bool) *discordgo.MessageEmbed {
+	hltbURL := fmt.Sprintf("%s://%s", hltbScheme, hltbHost)
+	embed := &discordgo.MessageEmbed{
+		Author: &discordgo.MessageEmbedAuthor{
+			Name: normaliseTitle(hltbQuery[i].GameTitle),
+			URL:  hltbQuery[i].GameURL,
+		},
+
+		Color: int(rand.Int63n(16777215)),
+		Thumbnail: &discordgo.MessageEmbedThumbnail{
+			URL: hltbURL + hltbQuery[i].ImageURL,
+		},
+	}
+	if len(hltbQuery[i].MainStory) > 0 {
+		embed.Fields = append(embed.Fields,
+			&discordgo.MessageEmbedField{Name: hltbQuery[i].MainStory[0], Value: hltbQuery[i].MainStory[1]})
+	}
+	if len(hltbQuery[i].MainExtra) > 0 {
+		embed.Fields = append(embed.Fields,
+			&discordgo.MessageEmbedField{Name: hltbQuery[i].MainExtra[0], Value: hltbQuery[i].MainExtra[1]})
+	}
+	if len(hltbQuery[i].Completionist) > 0 {
+		embed.Fields = append(embed.Fields,
+			&discordgo.MessageEmbedField{Name: hltbQuery[i].Completionist[0], Value: hltbQuery[i].Completionist[1]})
+	}
+	if paginated {
+		embed.Description = fmt.Sprintf("Lev distance: %d\nTerm similarity: %.1f%%", hltbQuery[i].LevDistance, hltbQuery[i].LevSimilarity*100)
+	}
+	return embed
+}
+
+func normaliseTitle(t string) string {
+	return strings.Join(strings.Fields(t), " ")
+}
+

--- a/stdcommands/howlongtobeat/levenshtein.go
+++ b/stdcommands/howlongtobeat/levenshtein.go
@@ -1,0 +1,46 @@
+// Simplest forms of Levenshtein Distance Calculation Functions
+// this is case-sensitive
+
+package howlongtobeat
+
+func lowest(a, b, c int) int {
+	if a < b {
+		if a < c {
+			return a
+		}
+	} else {
+		if b < c {
+			return b
+		}
+	}
+	return c
+}
+
+func levenshtein(str1, str2 []rune) (int, float64) {
+	str1len := len(str1)
+	str2len := len(str2)
+	distance := make([]int, str1len+1)
+
+	for i := 1; i <= str1len; i++ {
+		distance[i] = i
+	}
+	for j := 1; j <= str2len; j++ {
+		distance[0] = j
+		lastkey := j - 1
+		for i := 1; i <= str1len; i++ {
+			oldkey := distance[i]
+			var incr int
+			if str1[i-1] != str2[j-1] {
+				incr = 1
+			}
+
+			distance[i] = lowest(distance[i]+1, distance[i-1]+1, lastkey+incr)
+			lastkey = oldkey
+		}
+	}
+
+	levdistance := distance[str1len]
+	var similarity float64
+	similarity = (float64(str2len) - float64(levdistance)) / float64(str2len)
+	return levdistance, similarity
+}

--- a/stdcommands/howlongtobeat/queryfunctions.go
+++ b/stdcommands/howlongtobeat/queryfunctions.go
@@ -1,0 +1,101 @@
+package howlongtobeat
+
+import (
+	"io/ioutil"
+	"net/http"
+	"net/url"
+	"strconv"
+	"strings"
+
+	"github.com/PuerkitoBio/goquery"
+	"github.com/jonas747/yagpdb/commands"
+)
+
+func getGameData(searchTitle string) (string, error) {
+	data := url.Values{}
+	data.Set("queryString", searchTitle) //setting default request header query form data, the site uses
+	data.Add("t", "games")               // search type - for games, second option would be HLTB users
+	data.Add("sorthead", "popular")      // sort by release date,rating,popularity or name...  all parameters can be seen via header data, popular's the best
+	data.Add("sortd", "Normal Order")    // sorting, Normal or Reverse
+	data.Add("plat", "")                 // platform, empty string is for all
+	data.Add("length_type", "main")      // length range category, main is fine
+	data.Add("length_min", "")           // game length min
+	data.Add("length_max", "")           // game length max
+	data.Add("detail", "")               // extra information with user_stats ala speedruns, user rating etc...
+
+	u := &url.URL{
+		Scheme:   hltbScheme,
+		Host:     hltbHost,
+		Path:     hltbHostPath,
+		RawQuery: hltbRawQuery,
+	}
+
+	urlStr := u.String()
+
+	client := &http.Client{}
+	r, _ := http.NewRequest("POST", urlStr, strings.NewReader(data.Encode())) // URL-encoded payload
+	r.Header.Add("Content-Type", "application/x-www-form-urlencoded")
+	r.Header.Add("Accept", "*/*")
+	r.Header.Add("Content-Length", strconv.Itoa(len(data.Encode())))
+	r.Header.Add("User-Agent", "Mozilla-PAGST1.12")
+
+	resp, err := client.Do(r)
+	if err != nil {
+		return "", err
+	}
+
+	if resp.StatusCode != 200 {
+		return "", commands.NewPublicError("Unable to fetch data from howlongtobeat.com")
+	}
+	r.Body.Close()
+
+	bytes, err := ioutil.ReadAll(resp.Body)
+	if err != nil {
+		return "", err
+	}
+
+	stringBody := string(bytes)
+
+	return stringBody, nil
+}
+
+func parseGameData(gameName string, toReader *strings.Reader) ([]hltb, error) {
+	var hltbQuery []hltb
+	var queryParsed hltb
+
+	parseData, err := goquery.NewDocumentFromReader(toReader)
+	if err != nil {
+		return nil, err
+	}
+
+	parseData.Find("li").Each(func(_ int, sel *goquery.Selection) {
+		queryParsed.ImageURL = sel.Find("img").AttrOr("src", "")
+		queryParsed.GameURL = hltbURL + sel.Find("a").AttrOr("href", "")
+
+		queryParsed.GameTitle = strings.TrimSpace(sel.Find("h3").Text())
+		queryParsed.PureTitle = strings.TrimSpace(sel.Find("a").AttrOr("title", "")) //a tag has game title without &() etc
+		queryParsed.LevDistance, queryParsed.LevSimilarity = levenshtein([]rune(gameName), []rune(queryParsed.PureTitle))
+
+		/*if sel.Find(".search_list_tidbit_short").Length() > 0 { //maybe for future use
+			queryParsed.OnlineGame = true
+		}*/
+
+		sel.Find(".search_list_tidbit, .search_list_tidbit_short").Each(func(_ int, divSel *goquery.Selection) {
+			gameType := strings.TrimSpace(divSel.Text())
+			if gameType == "Main Story" || gameType == "Single-Player" || gameType == "Solo" {
+				queryParsed.MainStory = []string{gameType, strings.TrimSpace(divSel.Next().Text())}
+			}
+
+			if gameType == "Main + Extra" || gameType == "Co-Op" {
+				queryParsed.MainExtra = []string{gameType, strings.TrimSpace(divSel.Next().Text())}
+			}
+
+			if gameType == "Completionist" || gameType == "Vs." {
+				queryParsed.Completionist = []string{gameType, strings.TrimSpace(divSel.Next().Text())}
+			}
+		})
+		hltbQuery = append(hltbQuery, queryParsed)
+
+	})
+	return hltbQuery, nil
+}

--- a/stdcommands/stdcommands.go
+++ b/stdcommands/stdcommands.go
@@ -20,6 +20,7 @@ import (
 	"github.com/jonas747/yagpdb/stdcommands/dogfact"
 	"github.com/jonas747/yagpdb/stdcommands/findserver"
 	"github.com/jonas747/yagpdb/stdcommands/globalrl"
+	"github.com/jonas747/yagpdb/stdcommands/howlongtobeat"
 	"github.com/jonas747/yagpdb/stdcommands/guildunavailable"
 	"github.com/jonas747/yagpdb/stdcommands/info"
 	"github.com/jonas747/yagpdb/stdcommands/invite"
@@ -94,6 +95,7 @@ func (p *Plugin) AddCommands() {
 		viewperms.Command,
 		topgames.Command,
 		xkcd.Command,
+		howlongtobeat.Command,
 
 		// Maintenance
 		stateinfo.Command,


### PR DESCRIPTION
This pull requests adds several needed fixes to the DM templates in YAGPDB's custom command scripting.

We now perform each time a check if the targeted member object is present. If that fails to exist, the direct message will not be sent.
This is to remedy the "abuse" of `execCC` to still be able to send a leave DM, and should be quite future-proof.

Moreover, we add the info text we can see in `sendDM` to the other DM template `sendTemplateDM` - I was not able to find out how to send everything in one message, so it gets delivered as a second, additional message. Let me know what you think about that.

Of course, this might be a small-ish breaking change (again), but I think it is more important to block leave DMs entirely.
Everything works, as far as I can tell, fine on a selfhosted instance.

Cheers!