### PR TITLE
totally disable sending DM on leave message

### DIFF
--- a/common/templates/context.go
+++ b/common/templates/context.go
@@ -134,6 +134,8 @@ type Context struct {
 
 	CurrentFrame *contextFrame
 
+	IsExecedByLeaveMessage bool
+
 	contextFuncsAdded bool
 }
 
@@ -273,6 +275,7 @@ func (c *Context) Execute(source string) (string, error) {
 
 func (c *Context) executeParsed() (string, error) {
 	parsed := c.CurrentFrame.parsedTemplate
+
 	if c.IsPremium {
 		parsed = parsed.MaxOps(MaxOpsPremium)
 	} else {

--- a/common/templates/context_funcs.go
+++ b/common/templates/context_funcs.go
@@ -22,7 +22,7 @@ var ErrTooManyCalls = errors.New("too many calls to this function")
 var ErrTooManyAPICalls = errors.New("too many potential discord api calls function")
 
 func (c *Context) tmplSendDM(s ...interface{}) string {
-	if len(s) < 1 || c.IncreaseCheckCallCounter("send_dm", 1) || c.MS == nil {
+	if len(s) < 1 || c.IncreaseCheckCallCounter("send_dm", 1) || c.IncreaseCheckGenericAPICall() || c.MS == nil || c.IsExecedByLeaveMessage {
 		return ""
 	}
 
@@ -165,6 +165,10 @@ func (c *Context) ChannelArgNoDM(v interface{}) int64 {
 }
 
 func (c *Context) tmplSendTemplateDM(name string, data ...interface{}) (interface{}, error) {
+	if c.IsExecedByLeaveMessage {
+		return "", errors.New("Can't use sendTemplateDM on leave msg")
+	}
+
 	return c.sendNestedTemplate(nil, true, name, data...)
 }
 
@@ -334,6 +338,12 @@ func (c *Context) tmplSendMessage(filterSpecialMentions bool, returnID bool) fun
 			return ""
 		}
 
+		isDM := cid != c.ChannelArgNoDM(channel)
+		gName := c.GS.Name
+		info := fmt.Sprintf("Custom Command DM from the server **%s**", gName)
+		embedInfo := fmt.Sprintf("Custom Command DM from the server %s", gName)
+		icon := discordgo.EndpointGuildIcon(c.GS.ID, c.GS.Icon)
+
 		var m *discordgo.Message
 		msgSend := &discordgo.MessageSend{
 			AllowedMentions: discordgo.AllowedMentions{
@@ -343,16 +353,34 @@ func (c *Context) tmplSendMessage(filterSpecialMentions bool, returnID bool) fun
 		var err error
 
 		switch typedMsg := msg.(type) {
-
 		case *discordgo.MessageEmbed:
+			if isDM {
+				typedMsg.Footer = &discordgo.MessageEmbedFooter{
+					Text:    embedInfo,
+					IconURL: icon,
+				}
+			}
 			msgSend.Embed = typedMsg
 		case *discordgo.MessageSend:
 			msgSend = typedMsg
-			msgSend.AllowedMentions = discordgo.AllowedMentions{
-				Parse: parseMentions,
+			msgSend.AllowedMentions = discordgo.AllowedMentions{Parse: parseMentions}
+
+			if isDM {
+				if typedMsg.Embed != nil {
+					typedMsg.Embed.Footer = &discordgo.MessageEmbedFooter{
+						Text:    embedInfo,
+						IconURL: icon,
+					}
+				} else {
+					typedMsg.Content = info + "\n" + typedMsg.Content
+				}
 			}
 		default:
-			msgSend.Content = fmt.Sprint(msg)
+			if isDM {
+				msgSend.Content = info + "\n" + ToString(msg)
+			} else {
+				msgSend.Content = ToString(msg)
+			}
 		}
 
 		m, err = common.BotSession.ChannelMessageSendComplex(cid, msgSend)

--- a/customcommands/bot.go
+++ b/customcommands/bot.go
@@ -112,6 +112,8 @@ type DelayedRunCCData struct {
 	Member  *dstate.MemberState
 
 	UserKey interface{} `json:"user_key"`
+
+	IsExecedByLeaveMessage bool `json:"is_execed_by_leave_message"`
 }
 
 var cmdListCommands = &commands.YAGCommand{
@@ -305,6 +307,8 @@ func handleDelayedRunCC(evt *schEventsModels.ScheduledEvent, data interface{}) (
 		tmplCtx.Msg = dataCast.Message
 		tmplCtx.Data["Message"] = dataCast.Message
 	}
+
+	tmplCtx.IsExecedByLeaveMessage = dataCast.IsExecedByLeaveMessage
 
 	// decode userdata
 	if len(dataCast.UserData) > 0 {

--- a/customcommands/tmplextensions.go
+++ b/customcommands/tmplextensions.go
@@ -212,6 +212,7 @@ func tmplRunCC(ctx *templates.Context) interface{} {
 			}
 			newCtx.Data["ExecData"] = data
 			newCtx.Data["StackDepth"] = currentStackDepth + 1
+			newCtx.IsExecedByLeaveMessage = ctx.IsExecedByLeaveMessage
 
 			go ExecuteCustomCommand(cmd, newCtx)
 			return "", nil
@@ -223,6 +224,8 @@ func tmplRunCC(ctx *templates.Context) interface{} {
 
 			Member:  ctx.MS,
 			Message: ctx.Msg,
+
+			IsExecedByLeaveMessage: ctx.IsExecedByLeaveMessage,
 		}
 
 		// embed data using msgpack to include type information
@@ -284,6 +287,8 @@ func tmplScheduleUniqueCC(ctx *templates.Context) interface{} {
 			Member:  ctx.MS,
 			Message: ctx.Msg,
 			UserKey: stringedKey,
+
+			IsExecedByLeaveMessage: ctx.IsExecedByLeaveMessage,
 		}
 
 		// embed data using msgpack to include type information

--- a/notifications/plugin_bot.go
+++ b/notifications/plugin_bot.go
@@ -124,6 +124,7 @@ func HandleGuildMemberRemove(evt *eventsystem.EventData) (retry bool, err error)
 func sendTemplate(gs *dstate.GuildSet, cs *dstate.ChannelState, tmpl string, ms *dstate.MemberState, name string, censorInvites bool, enableSendDM bool) bool {
 	ctx := templates.NewContext(gs, cs, ms)
 	ctx.CurrentFrame.SendResponseInDM = cs.Type == discordgo.ChannelTypeDM
+	ctx.IsExecedByLeaveMessage = !enableSendDM
 
 	// since were changing the fields, we need a copy
 	msCop := *ms


### PR DESCRIPTION
Like #919, but with a clean history.
This pull requests adds several needed fixes to the DM templates in YAGPDB's custom command scripting.

We simply check if the template is being executed by the leave message, if that is true, it will fail to send the message.
This is to remedy the "abuse" of `execCC` to still be able to send a leave DM, and should be quite future-proof.

Moreover, we add the info text we can see in `sendDM` to the other DM template `sendTemplateDM` - Luckily @Pedro-Pessoa helped me with that, so a big kudos to him.

Of course, this might be a small-ish breaking change (again), but I think it is more important to block leave DMs entirely.
Everything works, as far as I can tell, fine on a selfhosted instance.

Cheers!