### PR TITLE
feat(stdcommands): channel flag for undelete

### DIFF
--- a/stdcommands/undelete/undelete.go
+++ b/stdcommands/undelete/undelete.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/jonas747/dcmd/v2"
 	"github.com/jonas747/discordgo"
+	"github.com/jonas747/dstate/v2"
 	"github.com/jonas747/yagpdb/bot"
 	"github.com/jonas747/yagpdb/commands"
 	"github.com/jonas747/yagpdb/common"
@@ -21,17 +22,30 @@ var Command = &commands.YAGCommand{
 	ArgSwitches: []*dcmd.ArgDef{
 		{Name: "a", Help: "from all users"},
 		{Name: "u", Help: "from a specific user", Type: dcmd.UserID, Default: 0},
+		{Name: "channel", Help: "Optional target channel", Type: dcmd.Channel},
 	},
 	RunFunc: func(data *dcmd.Data) (interface{}, error) {
 		allUsers := data.Switch("a").Value != nil && data.Switch("a").Value.(bool)
 		targetUser := data.Switch("u").Int64()
 
+		channel := data.GuildData.CS
+		if data.Switch("channel").Value != nil {
+			channel = data.Switch("channel").Value.(*dstate.ChannelState)
+
+			ok, err := bot.AdminOrPermMS(channel.ID, data.GuildData.MS, discordgo.PermissionReadMessages)
+			if err != nil {
+				return nil, err
+			} else if !ok {
+				return "You do not have permission to view that channel.", nil
+			}
+		}
+
 		if allUsers || targetUser != 0 {
-			ok, err := bot.AdminOrPermMS(data.ChannelID, data.GuildData.MS, discordgo.PermissionManageMessages)
+			ok, err := bot.AdminOrPermMS(channel.ID, data.GuildData.MS, discordgo.PermissionManageMessages)
 			if err != nil {
 				return nil, err
 			} else if !ok && targetUser == 0 {
-				return "You need `Manage Messages` permissions to view all users deleted messages", nil
+				return "You need `Manage Messages` permissions to view all users deleted messages.", nil
 			} else if !ok {
 				return "You need `Manage Messages` permissions to target a specific user other than yourself.", nil
 			}
@@ -43,8 +57,8 @@ var Command = &commands.YAGCommand{
 		data.GuildData.GS.RLock()
 		defer data.GuildData.GS.RUnlock()
 
-		for i := len(data.GuildData.CS.Messages) - 1; i >= 0 && numFound < 10; i-- {
-			msg := data.GuildData.CS.Messages[i]
+		for i := len(channel.Messages) - 1; i >= 0 && numFound < 10; i-- {
+			msg := channel.Messages[i]
 
 			if !msg.Deleted {
 				continue


### PR DESCRIPTION
As title states.

As #907 adds a channel flag for the `log` command, it would be only fair to grant `undelete` this feature as well.

Tested it on a selfhosted instance and works fine, as far as I can tell.