### PR TITLE
add triggering channel to report embed

### DIFF
--- a/moderation/commands.go
+++ b/moderation/commands.go
@@ -402,7 +402,7 @@ var ModerationCommands = []*commands.YAGCommand{
 					Name:    fmt.Sprintf("%s#%s (ID %d)", parsed.Author.Username, parsed.Author.Discriminator, parsed.Author.ID),
 					IconURL: discordgo.EndpointUserAvatar(parsed.Author.ID, parsed.Author.Avatar),
 				},
-				Description: fmt.Sprintf("🔍**Reported** %s#%s *(ID %d)*\n📄**Reason:** %s ([Logs](%s))", target.Username, target.Discriminator, target.ID, parsed.Args[1].Value, logLink),
+				Description: fmt.Sprintf("🔍**Reported** %s#%s <@%d>\n*(ID %d)*\n📄**Reason:** %s ([Logs](%s))\nIn: <#%d>", target.Username, target.Discriminator, target.ID, target.ID, parsed.Args[1].Value, logLink, parsed.GuildData.CS.ID),
 				Color:       0xee82ee,
 				Thumbnail: &discordgo.MessageEmbedThumbnail{
 					URL: discordgo.EndpointUserAvatar(target.ID, target.Avatar),


### PR DESCRIPTION
Noticed that it was quite handy to just jump to the channel with the old report message, so this pull request will also add the channel and link it.

We also mention the target user, as quickly calling up the profile might also come in handy, despite the classic Discord bug with `@invalid-user`.

Thanks in advance!