### PR TITLE
commands: show warning if existing prefix has space

### DIFF
--- a/commands/assets/commands.html
+++ b/commands/assets/commands.html
@@ -120,18 +120,26 @@
 
     $("#prefix").keyup(function() {
         const prefix = $(this).val();
-        if (prefix.length === 0) return;
-
-        $("#example-command-usage > code").text(`${prefix}ping`);
-
-        const existingWarning = $("#trailing-space-warning");
-        if (prefix[prefix.length - 1] === " ") {
-            if (existingWarning.length > 0) return; // don't duplicate warnings
-            addAlert("warning", `You have a trailing space in your command prefix, meaning that while '${prefix}ping' would trigger, '${prefix.trimRight()}ping' would not.`, "trailing-space-warning")
-        } else if (existingWarning.length) {
-            existingWarning.remove();
-        }
+        handlePrefixChange(prefix);
     });
+
+	$(function() {
+		handlePrefixChange($("#prefix").val());
+	});
+
+	function handlePrefixChange(prefix) {
+		if (prefix.length === 0) return;
+
+		$("#example-command-usage > code").text(`${prefix}ping`);
+
+		const existingWarning = $("#trailing-space-warning");
+		if (prefix[prefix.length - 1] === " ") {
+			if (existingWarning.length > 0) return; // don't duplicate warnings
+			addAlert("warning", `You have a trailing space in your command prefix, meaning that while '${prefix}ping' would trigger, '${prefix.trimRight()}ping' would not.`, "trailing-space-warning")
+		} else if (existingWarning.length) {
+			existingWarning.remove();
+		}
+	}
 </script>
 
 <style>


### PR DESCRIPTION
Extension to https://github.com/jonas747/yagpdb/pull/900 (I missed this in the original PR).
Issue is that the warning for trailing spaces does not show for existing prefixes with trailing spaces. In other words, if I set my prefix to `- ` and then save, the warning will disappear.

Works nicely on selfhost.
