### PR TITLE
cc: add warning when requiring no channels/roles

### DIFF
--- a/customcommands/assets/customcommands-editcmd.html
+++ b/customcommands/assets/customcommands-editcmd.html
@@ -310,14 +310,14 @@
                                 <h3>Channel/User role restrictions</h3>
                                 <div class="radio">
                                     <label>
-                                        <input type="radio" name="require_roles" value="on"
+                                        <input id="require-role-mode" type="radio" name="require_roles" value="on"
                                             {{if .CC.RolesWhitelistMode}}checked{{end}}>
                                         Require at least one of the roles in the following lists
                                     </label>
                                 </div>
                                 <div class="radio">
                                     <label>
-                                        <input type="radio" name="require_roles" value=""
+                                        <input id="ignore-role-mode" type="radio" name="require_roles" value=""
                                             {{if not .CC.RolesWhitelistMode}}checked{{end}}>
                                         Ignore the roles in the following list
                                     </label>
@@ -331,14 +331,14 @@
 
                                 <div class="radio">
                                     <label>
-                                        <input type="radio" name="require_channels" value="on"
+                                        <input id="require-channel-mode" type="radio" name="require_channels" value="on"
                                             {{if .CC.ChannelsWhitelistMode}}checked{{end}}>
                                         Only run in the following channels
                                     </label>
                                 </div>
                                 <div class="radio">
                                     <label>
-                                        <input type="radio" name="require_channels" value=""
+                                        <input id="ignore-channel-mode" type="radio" name="require_channels" value=""
                                             {{if not .CC.ChannelsWhitelistMode}}checked{{end}}>
                                         Ignore the channels in the following list
                                     </label>
@@ -485,6 +485,8 @@
 
     $(function () {
         triggerTypeChanged();
+        handleRestrictionChange($("#require-role-mode").prop("checked"), $("#command-roles"), "require-no-roles-warning", requireNoRolesWarning);
+        handleRestrictionChange($("#require-channel-mode").prop("checked"), $("#command-channels"), "require-no-channels-warning", requireNoChannelsWarning);
     })
 
     function onCCChanged(textArea) {
@@ -506,6 +508,44 @@
     }
 
     var idGen = 0
+
+    var requireNoRolesWarning = "Requiring no roles effectively disables your command, making it run for no one. If you want no role restrictions, set the mode to 'ignore roles' instead.";
+    var requireNoChannelsWarning = "Requiring no channels effectively disables your command, making it run for no one. If you want no channel restrictions, set the mode to 'ignore channels' instead.";
+
+    $("#require-role-mode").change(function() {
+        handleRestrictionChange($(this).prop("checked"), $("#command-roles"), "require-no-roles-warning", requireNoRolesWarning);
+    });
+    $("#ignore-role-mode").change(function() {
+        handleRestrictionChange(!$(this).prop("checked"), $("#command-roles"), "require-no-roles-warning", requireNoRolesWarning);
+    });
+    $("#command-roles").change(function() {
+        handleRestrictionChange($("#require-role-mode").prop("checked"), $(this), "require-no-roles-warning", requireNoRolesWarning);
+    });
+
+    $("#require-channel-mode").change(function() {
+        handleRestrictionChange($(this).prop("checked"), $("#command-channels"), "require-no-channels-warning", requireNoChannelsWarning);
+    });
+    $("#ignore-channel-mode").change(function() {
+        handleRestrictionChange(!$(this).prop("checked"), $("#command-channels"), "require-no-channels-warning", requireNoChannelsWarning);
+    });
+    $("#command-channels").change(function() {
+        handleRestrictionChange($("#require-channel-mode").prop("checked"), $(this), "require-no-channels-warning", requireNoChannelsWarning); 
+    });
+
+    function handleRestrictionChange(modeIsRequire, selectMenu, warningID, warningText) {
+        // requiring no roles/channels results in the command not being able to
+        // run anywhere, this is typically a mistake
+        const doWarn = modeIsRequire && selectMenu.val().length === 0; 
+        
+        const existingWarning = $(`#${warningID}`);
+        if (existingWarning.length > 0 && !doWarn) {
+            // remove existing warning if there's no need for it anymore
+            existingWarning.remove();
+        } else if (existingWarning.length === 0 && doWarn) {
+            // warning does not exist, so add it
+            addAlert("warning", warningText, warningID);
+        }
+    }
 </script>
 
 


### PR DESCRIPTION
To many people new to CC, requiring no roles/channels for CC seems like it should naturally have the same effect as ignoring no roles/channels. This is not the case -- requiring no roles/channels makes it run for nobody at all. Unfortunately, this is not something we can change without causing a breakage for people utilizing the current effect of requiring no roles/channels. A warning, however, seems appropriate considering how many people are confused by this (as seen in the help channels).

As far as I can see, it works fine on selfhost.
![Image of warnings](https://user-images.githubusercontent.com/56809242/118382464-c343cb80-b5aa-11eb-8015-e475b1f3b80f.png)

**Note:** There is some mild repetition in the lines added (registering the `change()` handlers) but I didn't feel like coming up with an appropriate abstraction was worth it considering it's just a few lines in total.
