### PR TITLE
templates: automatically deserialize custom types

### DIFF
--- a/common/templates/context.go
+++ b/common/templates/context.go
@@ -19,6 +19,7 @@ import (
 	"github.com/jonas747/yagpdb/common"
 	"github.com/jonas747/yagpdb/common/scheduledevents2"
 	"github.com/sirupsen/logrus"
+	"github.com/vmihailenco/msgpack"
 )
 
 var (
@@ -112,6 +113,10 @@ func RegisterSetupFunc(f ContextSetupFunc) {
 
 func init() {
 	RegisterSetupFunc(baseContextFuncs)
+
+	msgpack.RegisterExt(1, (*SDict)(nil))
+	msgpack.RegisterExt(2, (*Dict)(nil))
+	msgpack.RegisterExt(3, (*Slice)(nil))
 }
 
 // set by the premium package to return wether this guild is premium or not


### PR DESCRIPTION
Imagine if the following code just *worked*, like it intuitively should, without conversion:
```
{{$cslice := cslice 1 "hello" (sdict "a" "b")}}
{{dbSet 0 "slice" $cslice}}
{{$csliceFromDB := (dbGet 0 "slice").Value}}
{{$csliceFromDB.Append 5}}
{{(index $csliceFromDB 2).Get "a"}}
```

This PR does just that, by serializing sdicts, dicts, and cslices with a custom ext type to distinguish them from their underlying types. As far as I have seen while testing, this should never break existing code - the change is not retroactive. Furthermore, native sdicts/dicts/slices are all saved normally and are not deserialized into their equivalent custom types.