### PR TITLE
Display user ID in undelete command

### DIFF
--- a/stdcommands/undelete/undelete.go
+++ b/stdcommands/undelete/undelete.go
@@ -83,7 +83,7 @@ var Command = &commands.YAGCommand{
 			// Match found!
 			timeSince := common.HumanizeDuration(precision, time.Since(msg.ParsedCreated))
 
-			resp += fmt.Sprintf("`%s ago (%s)` **%s**#%s: %s\n\n", timeSince, msg.ParsedCreated.UTC().Format(time.ANSIC), msg.Author.Username, msg.Author.Discriminator, msg.ContentWithMentionsReplaced())
+			resp += fmt.Sprintf("`%s ago (%s)` **%s**#%s (ID %d): %s\n\n", timeSince, msg.ParsedCreated.UTC().Format(time.ANSIC), msg.Author.Username, msg.Author.Discriminator, msg.Author.ID, msg.ContentWithMentionsReplaced())
 			numFound++
 		}
 


### PR DESCRIPTION
As title states.

User suggestion on the server and felt like adding it.

Perhaps a flag `-id` might be a better idea to maintain back.comp - lmk what you think about that