### PR TITLE
Auto comments for PRs against master

### DIFF
--- a/.github/workflows/action.yml
+++ b/.github/workflows/action.yml
@@ -1,0 +1,28 @@
+name: Comment PR
+
+on:
+  pull_request:
+    branches:
+      - master
+
+jobs:
+  comment:
+    runs-on: ubuntu-latest
+    name: Comment on Pull Request
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v1
+
+      - if: ${{ !hashFiles('**/swearwords.go') }}
+        name: Comment
+        uses: thollander/actions-comment-pull-request@master
+        with:
+          message: "Hey @${{ github.actor }}! Thank you for your pull request.\nHowever, please do not open pull requests against the `master` branch, as stated in [CONTRIBUTING.md](../../CONTRIBUTING.md):\n> push the changes you make to the dev branch (Jonas747/yagpdb/dev).\n\nIf you still wish to keep this pull request open, please change the base branch.\nFor that, simply click the edit button next to the title of this pull request and select the new base;\nTo prevent conflicts, I suggest you first `git merge upstream/dev` on your local branch and push these new changes. Alternatively, `git rebase upstream/dev` on your local branch and then force-push."
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - if: ${{ hashFiles('**/swearwords.go') }}
+        name: Comment
+        uses: thollander/actions-comment-pull-request@master
+        with:
+          message: "Hey @${{github.actor }}! Thank you for your interest in contributing to YAGPDB.\nUnfortunately, basic automoderator will not receive **any** updates. To be able to use a custom list of swearwords, please use [automoderator v2](https://docs.yagpdb.xyz/tools-and-utilities/automoderator-v2).\n\nAdditionally, please do not open pull requests against the `master` branch, as stated in [CONTRIBUTING.md](../../CONTRIBUTING.md):\n> push the changes you make to the dev branch (Jonas747/yagpdb/dev).\n\nIf you still wish to keep this pull request open, please change the base branch.\nFor that, simply click the edit button next to the title of this pull request and select the new base;\nTo prevent conflicts, I suggest you first `git merge upstream/dev` on your local branch and push these new changes. Alternatively, `git rebase upstream/dev` on your local branch and then force-push."
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/action.yml
+++ b/.github/workflows/action.yml
@@ -31,7 +31,7 @@ jobs:
             To prevent conflicts, I suggest you first `git merge upstream/dev` on your local branch and push these new changes. Alternatively, `git rebase upstream/dev` on your local branch and then force-push.
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
-      - if: ${{ contains(steps.changed-files.outputs.modified_files, 'noCopy.txt') }}
+      - if: ${{ contains(steps.changed-files.outputs.modified_files, 'swearwords.go') }}
         name: automod comment
         uses: thollander/actions-comment-pull-request@master
         with:

--- a/.github/workflows/action.yml
+++ b/.github/workflows/action.yml
@@ -11,18 +11,40 @@ jobs:
     name: Comment on Pull Request
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v1
+        uses: actions/checkout@v2
 
-      - if: ${{ !hashFiles('**/swearwords.go') }}
-        name: Comment
+      - name: Get changed files
+        id: changed-files
+        uses: tj-actions/changed-files@v2.1
+
+      - if: ${{ !contains(steps.changed-files.outputs.modified_files, 'noCopy.txt') }}
+        name: master comment
         uses: thollander/actions-comment-pull-request@master
         with:
-          message: "Hey @${{ github.actor }}! Thank you for your pull request.\nHowever, please do not open pull requests against the `master` branch, as stated in [CONTRIBUTING.md](../../CONTRIBUTING.md):\n> push the changes you make to the dev branch (Jonas747/yagpdb/dev).\n\nIf you still wish to keep this pull request open, please change the base branch.\nFor that, simply click the edit button next to the title of this pull request and select the new base;\nTo prevent conflicts, I suggest you first `git merge upstream/dev` on your local branch and push these new changes. Alternatively, `git rebase upstream/dev` on your local branch and then force-push."
+          message: |
+            Hey @${{ github.actor }}! Thank you for your pull request.
+            However, please do not open pull requests against the `master` branch, as stated in [CONTRIBUTING.md](../../CONTRIBUTING.md):
+            > push the changes you make to the dev branch (Jonas747/yagpdb/dev).
+            
+            If you still wish to keep this pull request open, please change the base branch.
+            For that, simply click the edit button next to the title of this pull request and select the new base;
+            To prevent conflicts, I suggest you first `git merge upstream/dev` on your local branch and push these new changes. Alternatively, `git rebase upstream/dev` on your local branch and then force-push.
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
-      - if: ${{ hashFiles('**/swearwords.go') }}
-        name: Comment
+      - if: ${{ contains(steps.changed-files.outputs.modified_files, 'noCopy.txt') }}
+        name: automod comment
         uses: thollander/actions-comment-pull-request@master
         with:
-          message: "Hey @${{github.actor }}! Thank you for your interest in contributing to YAGPDB.\nUnfortunately, basic automoderator will not receive **any** updates. To be able to use a custom list of swearwords, please use [automoderator v2](https://docs.yagpdb.xyz/tools-and-utilities/automoderator-v2).\n\nAdditionally, please do not open pull requests against the `master` branch, as stated in [CONTRIBUTING.md](../../CONTRIBUTING.md):\n> push the changes you make to the dev branch (Jonas747/yagpdb/dev).\n\nIf you still wish to keep this pull request open, please change the base branch.\nFor that, simply click the edit button next to the title of this pull request and select the new base;\nTo prevent conflicts, I suggest you first `git merge upstream/dev` on your local branch and push these new changes. Alternatively, `git rebase upstream/dev` on your local branch and then force-push."
+          message: |
+            Hey @${{github.actor }}! Thank you for your interest in contributing to YAGPDB.
+            Unfortunately, basic automoderator will not receive **any** updates. To be able to use a custom list of swearwords, please use [automoderator v2](https://docs.yagpdb.xyz/tools-and-utilities/automoderator-v2).
+            As an alternative, you can amend your own words at the bottom of your basic automoderator settings.
+            For more information, please join the [support server](https://discord.gg/0vYlUK2XBKldPSMY).
+            
+            Additionally, please do not open pull requests against the `master` branch, as stated in [CONTRIBUTING.md](../../CONTRIBUTING.md):
+            > push the changes you make to the dev branch (Jonas747/yagpdb/dev).
+            
+            If you insist on wanting to keep this PR open, because it contains critical changes, please change the base branch to `dev`.
+            For that, simply click the edit button next to the title of this pull request and select the new base;
+            To prevent conflicts, I suggest you first `git merge upstream/dev` on your local branch and push these new changes. Alternatively, `git rebase upstream/dev` on your local branch and then force-push.
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
Due to the not infrequent PRs for `swearwords.go` against master and the like, I was so free and set up a workflow which automatically comments on such pull requests.

A pull request to `master` without changes to `swearwords.go` will mention the user to please not do that and instead change the base branch.

A pull request updating `swearwords.go` (again against `master`) will tell the user that we will **not** update legacy automoderator, however if they still wish to request critical changes, that they please change the base branch.

Both messages include a short description on how to change the base branch.

Was only able to test it on a private repository with limited capacities, but it works fine as far as I can tell.