### PR TITLE
fix(cc): visual bug with trigger text

### DIFF
--- a/customcommands/bot.go
+++ b/customcommands/bot.go
@@ -119,7 +119,7 @@ var cmdListCommands = &commands.YAGCommand{
 	Name:           "CustomCommands",
 	Aliases:        []string{"cc"},
 	Description:    "Shows a custom command specified by id or trigger, or lists them all",
-	ArgumentCombos: [][]int{[]int{0}, []int{1}, []int{}},
+	ArgumentCombos: [][]int{{0}, {1}, {}},
 	Arguments: []*dcmd.ArgDef{
 		{Name: "ID", Type: dcmd.Int},
 		{Name: "Trigger", Type: dcmd.String},
@@ -183,8 +183,8 @@ var cmdListCommands = &commands.YAGCommand{
 				Reader: &buf,
 			}
 		}
-
-		if cc.TextTrigger != "" {
+		// Every text-based custom command trigger has a numerical value less than 5, so this is quite safe to do
+		if cc.TriggerType < 5 {
 			if ccFile != nil {
 				msg = &discordgo.MessageSend{
 					Content: fmt.Sprintf("#%d - %s: `%s` - Case sensitive trigger: `%t` Group: `%s`",


### PR DESCRIPTION
There is a visual bug with the `cc` command that, when initially set a text trigger and then a changed trigger type not based on text, this text-trigger will still be shown:
![output of cc command](https://user-images.githubusercontent.com/71897876/119271711-f1f12000-bc02-11eb-929e-215989fda3f4.png)

This pull request aims to fix that issue.
Bug pointed out by `bonbom_#6542` on the support server.
[relevant bug report](https://discord.com/channels/166207328570441728/214439334089195521/846072305482203167)

Thanks in advance!