### PR TITLE
moderation: Limit ban and kick reason length

### DIFF
--- a/moderation/commands.go
+++ b/moderation/commands.go
@@ -6,6 +6,7 @@ import (
 	"strconv"
 	"strings"
 	"time"
+	"unicode/utf8"
 
 	"emperror.dev/errors"
 	"github.com/jinzhu/gorm"
@@ -149,6 +150,10 @@ var ModerationCommands = []*commands.YAGCommand{
 				return nil, err
 			}
 
+			if utf8.RuneCountInString(reason) > 470 {
+				return "Error: Reason too long (can be max 470 characters).", nil
+			}
+
 			ddays := int(config.DefaultBanDeleteDays.Int64)
 			if parsed.Switches["ddays"].Value != nil {
 				ddays = parsed.Switches["ddays"].Int()
@@ -236,6 +241,10 @@ var ModerationCommands = []*commands.YAGCommand{
 			reason, err = MBaseCmdSecond(parsed, reason, config.KickReasonOptional, discordgo.PermissionKickMembers, config.KickCmdRoles, config.KickEnabled)
 			if err != nil {
 				return nil, err
+			}
+
+			if utf8.RuneCountInString(reason) > 470 {
+				return "Error: Reason too long (can be max 470 characters).", nil
 			}
 
 			var msg *discordgo.Message


### PR DESCRIPTION
As title states.
Because Discord only allows for a max reason length of 512 characters, we limit the reason to 470 characters, as we prepend it with the username and discriminator as well as two formatting characters.
As it stands, YAGPDB just responds with 
> Something went wrong when running this command, either discord or the bot may be having issues.

This pull request adds a check and responds with
> Error: Reason too long (can be max 470 characters).

Should the reason's length cause it to exceed max character count.

Relevant [suggestion](https://discord.com/channels/166207328570441728/356486960417734666/844968308360216646) on the support server.

Thanks in advance!