### PR TITLE
reddit: disallow all mentions

### DIFF
--- a/reddit/redditbot.go
+++ b/reddit/redditbot.go
@@ -209,6 +209,9 @@ func (p *PostHandlerImpl) handlePost(post *reddit.Link, filterGuild int64) error
 			SourceID:        idStr,
 			UseWebhook:      true,
 			WebhookUsername: webhookUsername,
+			AllowedMentions: discordgo.AllowedMentions{
+				Parse: []discordgo.AllowedMentionType{},
+			},
 		}
 
 		if item.UseEmbeds {


### PR DESCRIPTION
Sometimes, when reddit users think they're funny, they use the underlying format for role and/or user mentions, which of course then mentions that role/user.

As webhooks also have an `allowed_mentions` property, setting this to empty should fix this kind of behavior - this is what this pull request aims to accomplish.
I wasn't entirely sure how webhooks behave, but I think it's better to be safe than sorry.

Couldn't test it on my selfhosted instance, as I host locally and reddit wants a legit URI for my application, different from `localhost`.

Thanks in advance!