### PR TITLE
rolemenu: add alias to `remove` subcommand

### DIFF
--- a/rolecommands/bot.go
+++ b/rolecommands/bot.go
@@ -65,6 +65,7 @@ func (p *Plugin) AddCommands() {
 	cmdRemoveRoleMenu := &commands.YAGCommand{
 		Name:                "Remove",
 		CmdCategory:         categoryRoleMenu,
+		Aliases:             []string{"rm"},
 		Description:         "Removes a rolemenu from a message.",
 		LongDescription:     "The message won't be deleted and the bot will not do anything with reactions on that message\n\n" + msgIDDocs,
 		RequireDiscordPerms: []int64{discordgo.PermissionManageServer},


### PR DESCRIPTION
As title states.

This was a user suggestion on the server. Seeing as the `create` subcommand also has an alias `c`, it's only fair to also give an alias to `remove`, namely `rm`.

Thanks in advance : )