### PR TITLE
remove "queer" from swearwords.go

### DIFF
--- a/automod_legacy/swearwords.go
+++ b/automod_legacy/swearwords.go
@@ -51,7 +51,6 @@ var BuiltinSwearWords = map[string]bool{
 	"poop":        true,
 	"pube":        true,
 	"pussy":       true,
-	"queer":       true,
 	"scrotum":     true,
 	"sex":         true,
 	"shit":        true,


### PR DESCRIPTION
Recommended to be removed by the user max-content in  #957 and #667 
"queer" is a very commonly used word in the LGBTQ+ community and is nowadays used as a non-offensive and neutral or positive self-identifier.
Leaving the word in swearwords.go for legacy automod could be seen very negatively, especially now during pride month.

While it is true that the term was used as a slur once in the past, it since has been reclaimed by the LGBTQ+ community and is generally seen as positive or non-offensive. 