### PR TITLE
Minor fixes for swearwords.go

### DIFF
--- a/automod_legacy/swearwords.go
+++ b/automod_legacy/swearwords.go
@@ -1,7 +1,6 @@
 package automod_legacy
 
-// This list is in alphabethical order
-// Open a pr or bug me on discord if you want a word added
+// These words are listed in in alphabethical order.
 var BuiltinSwearWords = map[string]bool{
 	"anal":        true,
 	"anus":        true,
@@ -59,8 +58,8 @@ var BuiltinSwearWords = map[string]bool{
 	"smegma":      true,
 	"spunk":       true,
 	"tit":         true,
-	"tranny":       true,
-	"trannies":     true,
+	"tranny":      true,
+	"trannies":    true,
 	"tosser":      true,
 	"turd":        true,
 	"twat":        true,


### PR DESCRIPTION
1. Changed the sentence of first comment for a little bit, to be somewhat clearer.
1. **Removed second comment** which encourages PR or contacting for adding words. This is because of #940 and [many pull requests](https://github.com/jonas747/yagpdb/pulls?q=swearwords.go+is%3Apr+is%3Aclosed) which are involved in editing `swearwords.go` file but not merged. **This is the main point of this pull request.**
1. It seems there are some whitespaces for vertically aligning `true` boolean, but two of them are not correctly aligned when viewing `swearwords.go` file on GitHub, as well as in Visual Studio Code with monospaced font. I removed a single whitespace from each of those two to fix alignment.

![image](https://user-images.githubusercontent.com/43488966/120806243-93705e00-c581-11eb-938a-e345e072af81.png)

![image](https://user-images.githubusercontent.com/43488966/120806279-9ff4b680-c581-11eb-8d92-3164a1272ce2.png)