### PR TITLE
templates: indirect value passed to AppendSlice()

### DIFF
--- a/common/templates/context.go
+++ b/common/templates/context.go
@@ -636,7 +636,7 @@ func (s Slice) Set(index int, item interface{}) (string, error) {
 }
 
 func (s Slice) AppendSlice(slice interface{}) (interface{}, error) {
-	val := reflect.ValueOf(slice)
+	val, _ := indirect(reflect.ValueOf(slice))
 	switch val.Kind() {
 	case reflect.Slice, reflect.Array:
 	// this is valid


### PR DESCRIPTION
When https://github.com/jonas747/yagpdb/commit/636e5153cfdc67b10be0044d2e563236db729856 was deployed on some servers, the following code formerly used for conversion broke:
```
{{$cslice := cslice 1 "two" 3.0}}  
{{dbSet 0 "example" $cslice}}
{{$slice := (dbGet 0 "example").Value}}
{{$cslice_converted := (cslice).AppendSlice $slice}}
```
`AppendSlice` was returning an error stating that the value passed was not an array or slice.
The reason is that previously the only custom slice type that would show up is `templates.Slice`, a value type, while deserializing the cslice saved to DB results in a `*templates.Slice` - a pointer. `AppendSlice` only accepts `templates.Slice`s, not pointers, causing the issue in question.
The solution is to perform an indirection before handling the value in `AppendSlice`.

Only cslices are affected; dicts and sdicts already do this in their respective functions.