### PR TITLE
templates: fix <channel>.Mention() method when called on nil ptr

### DIFF
--- a/common/templates/structs.go
+++ b/common/templates/structs.go
@@ -1,6 +1,8 @@
 package templates
 
 import (
+	"errors"
+
 	"github.com/jonas747/discordgo"
 	"github.com/jonas747/dstate/v3"
 )
@@ -23,8 +25,11 @@ type CtxChannel struct {
 	ParentID             int64                            `json:"parent_id"`
 }
 
-func (c *CtxChannel) Mention() string {
-	return "<#" + discordgo.StrID(c.ID) + ">"
+func (c *CtxChannel) Mention() (string, error) {
+	if c == nil {
+		return "", errors.New("channel not found")
+	}
+	return "<#" + discordgo.StrID(c.ID) + ">", nil
 }
 
 func CtxChannelFromCS(cs *dstate.ChannelState) *CtxChannel {


### PR DESCRIPTION
Long story, but essentially:
```
{{ $x := getChannel 0 }}
{{/* x is a nil pointer of type *templates.CtxChannel */}}
{{ $x.Mention }}
{{/* Rather than erroring, the template library calls Mention() on the nil pointer (??) and causes a panic when c.ID is accessed */}}
```
Technically speaking this is sorta-ish a bug on the template library side - see https://github.com/golang/go/issues/28242, which has essentially the same repro. There, they decided to keep this behavior (calling methods with nil receivers) because it's a valid thing to do in Golang. However, they did make a change - better error messages to make it clear what the issue was; the commit was included in the batch update PR I sent to the template repo (https://github.com/jonas747/template/pull/2) but isn't deployed.

Anyhow, I think this does require a hotfix and this is exactly that, to prevent the nil pointer dereference from occurring.