### PR TITLE
streaming: ignore other bots

### DIFF
--- a/streaming/assets/streaming.html
+++ b/streaming/assets/streaming.html
@@ -27,6 +27,7 @@
                                 streamers!<br>
                                 Note: This only checks your server members streaming status, if you need something else
                                 there are several dedicated bots for the purpose of announcing streams.
+                                Bots will be ignored.
                             </p>
                         </div>
                         <!-- /.col-lg-12 -->

--- a/streaming/bot.go
+++ b/streaming/bot.go
@@ -240,9 +240,9 @@ func CheckPresenceSparse(client radix.Client, config *Config, p *discordgo.Prese
 
 	// Now the real fun starts
 	// Either add or remove the stream
-	if p.Status != discordgo.StatusOffline && mainActivity != nil && mainActivity.URL != "" && mainActivity.Type == 1 {
+	if p.Status != discordgo.StatusOffline && mainActivity != nil && mainActivity.URL != "" && mainActivity.Type == 1 && !p.User.Bot {
 
-		// Streaming
+		// Streaming and not a bot
 
 		if !config.MeetsRequirements(p.Roles, mainActivity.State, mainActivity.Details) {
 			RemoveStreaming(client, config, gs.ID, p.User.ID, p.Roles)
@@ -300,8 +300,8 @@ func CheckPresence(client radix.Client, config *Config, ms *dstate.MemberState, 
 
 	// Now the real fun starts
 	// Either add or remove the stream
-	if ms.Presence != nil && ms.Presence.Status != dstate.StatusOffline && ms.Presence.Game != nil && ms.Presence.Game.URL != "" && ms.Presence.Game.Type == 1 {
-		// Streaming
+	if ms.Presence != nil && ms.Presence.Status != dstate.StatusOffline && ms.Presence.Game != nil && ms.Presence.Game.URL != "" && ms.Presence.Game.Type == 1 && !ms.User.Bot {
+		// Streaming and not a bot
 
 		if !config.MeetsRequirements(ms.Member.Roles, ms.Presence.Game.State, ms.Presence.Game.Details) {
 			RemoveStreaming(client, config, gs.ID, ms.User.ID, ms.Member.Roles)


### PR DESCRIPTION
Fairly trivial, bots shouldn't get the role as this feature is technically meant only for members - No sane person would seriously want to have the "streams" of a bot announced, as those bots do it mostly for cosmetic reasons. (Purple is a nice color!!)

This pull request extends the check for the presence by a check whether the member in question is not a bot - if so, continue and grant the role.

Let me know when I missed something.