### PR TITLE
templates: indirect the input value for tmplSort

### DIFF
--- a/common/templates/context_funcs.go
+++ b/common/templates/context_funcs.go
@@ -1342,7 +1342,7 @@ func (c *Context) tmplSort(input interface{}, sortargs ...interface{}) (interfac
 		return "", ErrTooManyCalls
 	}
 
-	inputSlice := reflect.ValueOf(input)
+	inputSlice, _ := indirect(reflect.ValueOf(input))
 	switch inputSlice.Kind() {
 	case reflect.Slice, reflect.Array:
 		// valid


### PR DESCRIPTION
Following #969 and #963 because of #936

The input value for the tmplSort function should be indirected so that it can work with deserialized values from databases.