### PR TITLE
commands: handle user value type in exec

### DIFF
--- a/commands/tmplexec.go
+++ b/commands/tmplexec.go
@@ -163,6 +163,9 @@ func execCmd(tmplCtx *templates.Context, dryRun bool, m *discordgo.MessageCreate
 		case *discordgo.User:
 			cmdLine += "<@" + strconv.FormatInt(t.ID, 10) + ">"
 			fakeMsg.Mentions = append(fakeMsg.Mentions, t)
+		case discordgo.User:
+			cmdLine += "<@" + strconv.FormatInt(t.ID, 10) + ">"
+			fakeMsg.Mentions = append(fakeMsg.Mentions, &t)
 		case []string:
 			for i, str := range t {
 				if i != 0 {


### PR DESCRIPTION
Handle `discordgo.User` types in exec.
Typically the type is `*discordgo.User` but the value type can pop up in some places. In particular, the `User` field on DB entries is a `discordgo.User`, not a `*discordgo.User`.

Thus, the following code:
```
{{dbSet .User.ID "test" 0}}
{{$u := (dbGet .User.ID "test").User}}
{{exec "warn" $u "test"}}
```
...would error out with `Unknown type in exec, only strings, numbers, users and string slices are supported`.