### PR TITLE
stdcommands: more answers to advice

### DIFF
--- a/stdcommands/advice/advice.go
+++ b/stdcommands/advice/advice.go
@@ -2,6 +2,7 @@ package advice
 
 import (
 	"encoding/json"
+	"math/rand"
 	"net/http"
 	"net/url"
 
@@ -15,7 +16,7 @@ var Command = &commands.YAGCommand{
 	Name:        "Advice",
 	Description: "Don't be afraid to ask for advice!",
 	Arguments: []*dcmd.ArgDef{
-		&dcmd.ArgDef{Name: "What", Type: dcmd.String},
+		{Name: "What", Type: dcmd.String},
 	},
 	DefaultEnabled:      true,
 	SlashCommandEnabled: true,
@@ -56,7 +57,7 @@ var Command = &commands.YAGCommand{
 		} else {
 			cast := decoded.(*SearchAdviceResp)
 			if len(cast.Slips) > 0 {
-				advice = cast.Slips[0].Advice
+				advice = cast.Slips[rand.Intn(len(cast.Slips))].Advice
 			}
 		}
 


### PR DESCRIPTION
Quite an old [suggestion](https://discord.com/channels/166207328570441728/356486960417734666/692984043389845524) which apparently was not implemented or PRd yet.

This pull request adds a little sugar to the advice command: Instead of always indexing the first item upon a successful search, we take a random item of the returned array of advice slips. Not a huge change, however I tested it as usual on a selfhosted instance and the results speak for themselves:
![screenshot](https://user-images.githubusercontent.com/71897876/122134672-5fc5eb80-ce3f-11eb-86f9-34b0700b37e6.png)
(sorry for compact mode - ATBDB is my selfhosted instance, LAGPDB is the officially hosted instance).

As you can clearly see, there is now more "advice" to receive, the command still functions the same. I was also so free to remove the unnecessarily redundant type declaration for the ArgDef.

Cheers : )