### PR TITLE
logs: show underlying JSON of embeds

### DIFF
--- a/logs/logs.go
+++ b/logs/logs.go
@@ -4,6 +4,7 @@ package logs
 
 import (
 	"database/sql"
+	"encoding/json"
 	"fmt"
 	"strconv"
 	"strings"
@@ -113,8 +114,14 @@ func CreateChannelLog(ctx context.Context, config *models.GuildLoggingConfig, gu
 			body += fmt.Sprintf(" (Attachment: %s)", attachment.URL)
 		}
 
-		if len(v.Embeds) > 0 {
-			body += fmt.Sprintf(" (%d embeds is not shown)", len(v.Embeds))
+		// serialise embeds to their underlying JSON
+		for count, embed := range v.Embeds {
+			marshalled, err := json.Marshal(embed)
+			if err != nil {
+				continue
+			}
+
+			body += fmt.Sprintf("\nEmbed %d: %s", count, marshalled)
 		}
 
 		// Strip out nul characters since postgres dont like them and discord dont filter them out (like they do in a lot of other places)


### PR DESCRIPTION
As title states.
This was also a fairly old [suggestion](https://discord.com/channels/166207328570441728/356486960417734666/754098618620706906) on the support server:
> For logging with the `-logs` command, specifically logging embeds, use the JSON version of the embed so that there is at least some form of embed logging, rather than "(x embeds is not shown)".

This pull request adds this kind of behavior, although I was not able to indent it beautifully for some reason. 
Let me know what needs to be changed for it to do that, or if this is intentional.
I decided to take this action on all embeds of each message, if they exist. Feedback regarding this is appreciated, as well.

As usual, I tested this on an selfhosted instance and as far as I can tell, it works fine:
![screenshot of logs on selfhost](https://user-images.githubusercontent.com/71897876/122253784-c80ede80-cecc-11eb-9c6f-f150e54b7324.png)

Cheers!