### PR TITLE
Docker Improvements

### DIFF
--- a/yagpdb_docker/Dockerfile
+++ b/yagpdb_docker/Dockerfile
@@ -1,47 +1,40 @@
 FROM golang:stretch as builder
 
-WORKDIR /appbuild/yagpdb/
-
-COPY go.mod .
-COPY go.sum .
-
+WORKDIR /appbuild/yagpdb
+COPY go.mod go.sum .
 RUN go mod download
-
 COPY . .
 
-WORKDIR /appbuild/yagpdb/cmd/yagpdb
+WORKDIR /bin/yagpdb
+COPY cmd/yagpdb/posts posts/
+COPY cmd/yagpdb/static static/
+COPY cmd/yagpdb/templates templates/
+# Handle templates for plugins automatically
+COPY */assets/*.html templates/plugins/
 
-RUN CGO_ENABLED=0 GOOS=linux go build -ldflags "-X github.com/jonas747/yagpdb/common.VERSION=$(git describe --tags)" -v
+WORKDIR /appbuild/yagpdb/cmd/yagpdb
+RUN CGO_ENABLED=0 GOOS=linux go build -ldflags "-X github.com/jonas747/yagpdb/common.VERSION=$(git describe --tags)" -v -o /bin/yagpdb
+
+
 
 FROM alpine:latest
 
 WORKDIR /app
-VOLUME /app/soundboard \
+VOLUME \
+  /app/soundboard \
   /app/cert
 EXPOSE 80 443
 
 # We need the X.509 certificates for client TLS to work.
-# Also install tzdata, needed for Go timezone support, 
+# Also install tzdata, needed for Go timezone support,
 # and ffmpeg for soundboard support,
-# as the alpine image does not come with them by default. 
-RUN apk --no-cache add ca-certificates \
-  ffmpeg \
-  tzdata
+# as the alpine image does not come with them by default.
+RUN apk --no-cache add \
+ca-certificates \
+ffmpeg \
+tzdata
 
-# Handle templates for plugins automatically
-COPY --from=builder /appbuild/yagpdb/*/assets/*.html templates/plugins/
+COPY --from=builder /bin/yagpdb .
 
-COPY --from=builder /appbuild/yagpdb/cmd/yagpdb/templates templates/
-COPY --from=builder /appbuild/yagpdb/cmd/yagpdb/posts posts/
-COPY --from=builder /appbuild/yagpdb/cmd/yagpdb/static static/
-
-COPY --from=builder /appbuild/yagpdb/cmd/yagpdb .
-
-# add extra flags here when running YAGPDB
-# Set "-exthttps=true" if using a TLS-enabled proxy such as
-# jrcs/letsencrypt-nginx-proxy-companion
-# Set "-https=false" do disable https
-ENV extra_flags ""
-
-# `exec` allows us to receive shutdown signals.
-CMD exec /app/yagpdb -all -pa $extra_flags
+ENTRYPOINT ["/app/yagpdb"]
+CMD ["-all", "-pa", "-exthttps=false", "-https=true"]

--- a/yagpdb_docker/Dockerfile
+++ b/yagpdb_docker/Dockerfile
@@ -20,9 +20,7 @@ RUN CGO_ENABLED=0 GOOS=linux go build -ldflags "-X github.com/jonas747/yagpdb/co
 FROM alpine:latest
 
 WORKDIR /app
-VOLUME \
-  /app/soundboard \
-  /app/cert
+VOLUME ["/app/soundboard", "/app/cert"]
 EXPOSE 80 443
 
 # We need the X.509 certificates for client TLS to work.

--- a/yagpdb_docker/Dockerfile
+++ b/yagpdb_docker/Dockerfile
@@ -29,10 +29,7 @@ EXPOSE 80 443
 # Also install tzdata, needed for Go timezone support,
 # and ffmpeg for soundboard support,
 # as the alpine image does not come with them by default.
-RUN apk --no-cache add \
-ca-certificates \
-ffmpeg \
-tzdata
+RUN apk --no-cache add ca-certificates ffmpeg tzdata
 
 COPY --from=builder /bin/yagpdb .
 

--- a/yagpdb_docker/docker-compose.dev.yml
+++ b/yagpdb_docker/docker-compose.dev.yml
@@ -18,7 +18,7 @@ services:
       dockerfile: yagpdb_docker/Dockerfile
     restart: unless-stopped
     command:
-      - "/app/yagpdb"
+      # - "/app/yagpdb"
       - "-all"
       - "-pa"
       - "-exthttps=false"

--- a/yagpdb_docker/docker-compose.proxied.yml
+++ b/yagpdb_docker/docker-compose.proxied.yml
@@ -14,9 +14,15 @@ networks:
 
 services:
   app:
-    image: caskd/yagpdb
+    # We don't provide an official image, but there is a community-made image you can try:
+    #  - teyker/yagpdb (https://hub.docker.com/r/teyker/yagpdb)
+    #
+    # Note that we do not take responsibility for anything that happens as a result of using
+    # the image above.
+    image: PUT_YOUR_OWN_IMAGE_HERE
     restart: unless-stopped
     command:
+      # - "/app/yagpdb"
       - "-all"
       - "-pa"
       - "-exthttps=true"
@@ -50,4 +56,3 @@ services:
       - default
     env_file:
       - db.env
-

--- a/yagpdb_docker/docker-compose.yml
+++ b/yagpdb_docker/docker-compose.yml
@@ -19,6 +19,7 @@ services:
     image: PUT_YOUR_OWN_IMAGE_HERE
     restart: unless-stopped
     command:
+      # - "/app/yagpdb"
       - "-all"
       - "-pa"
       - "-exthttps=false"
@@ -54,4 +55,3 @@ services:
       - default
     env_file:
       - db.env
-


### PR DESCRIPTION
This PR is intended to improve the current Docker support.

Dockerfile:
Added Entrypoint and modified CMD:
- The current Dockerfile does not match the syntax of docker-compose.yml and docker-compose.proxied.yml.
Those have currently no specification of the executable path and thus would fail to start a container from an image build by the current Dockerfile. 
Additional, the current CMD is written in shell format, which should be exec format instead.
Since the yagpdb_app container is only supposed to run an executable and nothing else, it would be reasonable to change the current shell format CMD to an exec format Entrypoint (/app/yagpdb) + CMD for additional commands.

Removed ENV extra_flags:
- There should be no reason to have such an ENV in the running container, since you can already specify those with CMD/command

Moved copy operations to builder:
- Using /appbuild/yagpdb/ as workdir for mod download and go build. Move all the necessary files + binary to /bin/yagpdb so we can copy all files in one image layer to the final image. And importantly exclude the unnecessary files in yagpdb/cmd/yagpdb/ (build.sh; copytemplates.sh; main.go; sampleenvfile) since they are not required inside the image and only take up unnecessary space. 

Formating changes:
- Removed white space in front of the "RUN apk" lines since it will result in a weird syntax on docker hub
edit: changed "RUN apk" and "volume" to one-liners.



docker-compose.yml:
- Added commented executable path in command, since it is currently used in the public community image by teyker/teyloll

docker-compose.proxied.yml:
- Updated to match docker-compose.yml

docker-compose.dev.yml:
- Commented out the executable path in order to match the new Dockerfile