### PR TITLE
reminders: fix wording, add new command alias

### DIFF
--- a/reminders/plugin_bot.go
+++ b/reminders/plugin_bot.go
@@ -37,7 +37,7 @@ var cmds = []*commands.YAGCommand{
 	{
 		CmdCategory:  commands.CategoryTool,
 		Name:         "Remindme",
-		Description:  "Schedules a reminder, example: 'remindme 1h30min are you alive still?'",
+		Description:  "Schedules a reminder, example: 'remindme 1h30min are you still alive?'",
 		Aliases:      []string{"remind", "reminder"},
 		RequiredArgs: 2,
 		Arguments: []*dcmd.ArgDef{
@@ -91,7 +91,8 @@ var cmds = []*commands.YAGCommand{
 	{
 		CmdCategory:         commands.CategoryTool,
 		Name:                "CReminders",
-		Description:         "Lists reminders in channel, only users with 'manage server' permissions can use this.",
+		Aliases:             []string{"channelreminders"},
+		Description:         "Lists reminders in channel, only users with 'manage channel' permissions can use this.",
 		SlashCommandEnabled: true,
 		DefaultEnabled:      true,
 		RunFunc: func(parsed *dcmd.Data) (interface{}, error) {


### PR DESCRIPTION
This pull request fixes the wording of the `creminders` command. Prior to this, its help-text stated that the user needs `manage_server` permission to run this command, which is wrong - instead, it only requires `manage_channel` permission.

Furthermore, this PR also adds a new alias to said command, namely `channelreminders` - I think this is a bit more intuitive as to what the command does. Feel free to comment on that one : )

Lastly, I also fixed the wording in the `remindme` description, the word order felt a little off.

All in all, not a huge pull request.

Cheers!