### PR TITLE
premium: fix slot count in titles

### DIFF
--- a/premium/patreonpremiumsource/patreonpremiumsource.go
+++ b/premium/patreonpremiumsource/patreonpremiumsource.go
@@ -107,7 +107,7 @@ func UpdatePremiumSlots(ctx context.Context) error {
 		if slotsForPledge > len(userSlots) {
 			// Need to create more slots
 			for i := 0; i < slotsForPledge-len(userSlots); i++ {
-				title := fmt.Sprintf("Patreon Slot #%d", i+len(userSlots))
+				title := fmt.Sprintf("Patreon Slot #%d", 1+i+len(userSlots))
 				slot, err := premium.CreatePremiumSlot(ctx, tx, userID, "patreon", title, "Slot is available for as long as the pledge is active on patreon", int64(i+len(userSlots)), -1, premium.PremiumTierPremium)
 				if err != nil {
 					tx.Rollback()


### PR DESCRIPTION
This PR aims to fix an issue wherein pledging for more premium slots than what's available from the existing plan, causes the slot title to increment in an unintended way, i.e - start the count from `0+len(userSlots)` instead of `1+len(userSlots)`.

The underlying image shows a scenario where 4 additional slots were pledged for, resulting in the count of additional slots to begin from 1 instead of 2:
![image](https://user-images.githubusercontent.com/67655446/122638924-59fa2f80-d0f7-11eb-9104-54f5bcc06928.png)

This change fixes it, by simply adding a 1 to the calculated value.