### PR TITLE
discordlogger: remove discord invites from guild names

### DIFF
--- a/discordlogger/discordlogger.go
+++ b/discordlogger/discordlogger.go
@@ -65,9 +65,9 @@ func EventHandler(evt *eventsystem.EventData) (retry bool, err error) {
 			logger.WithError(err).Error("failed fetching guild data")
 		}
 
-		msg = fmt.Sprintf(":x: Left guild **%s** :(", common.ReplaceServerInvites(guildData.Name, int64(confBotLeavesJoins.GetInt()), "[removed-server-invite]"))
+		msg = fmt.Sprintf(":x: Left guild **%s** :(", common.ReplaceServerInvites(guildData.Name, 0, "[removed-server-invite]"))
 	case eventsystem.EventNewGuild:
-		msg = fmt.Sprintf(":white_check_mark: Joined guild **%s** :D", common.ReplaceServerInvites(evt.GuildCreate().Guild.Name, int64(confBotLeavesJoins.GetInt()), "[removed-server-invite]"))
+		msg = fmt.Sprintf(":white_check_mark: Joined guild **%s** :D", common.ReplaceServerInvites(evt.GuildCreate().Guild.Name, 0, "[removed-server-invite]"))
 	}
 
 	msg += fmt.Sprintf(" (now connected to %d servers)", count)

--- a/discordlogger/discordlogger.go
+++ b/discordlogger/discordlogger.go
@@ -12,7 +12,7 @@ import (
 )
 
 var (
-	// Send bot leaves joins to this disocrd channel
+	// Send bot leaves joins to this discord channel
 	confBotLeavesJoins = config.RegisterOption("yagpdb.botleavesjoins", "Channel to log added/left servers to", 0)
 
 	logger = common.GetPluginLogger(&Plugin{})
@@ -65,9 +65,9 @@ func EventHandler(evt *eventsystem.EventData) (retry bool, err error) {
 			logger.WithError(err).Error("failed fetching guild data")
 		}
 
-		msg = fmt.Sprintf(":x: Left guild **%s** :(", guildData.Name)
+		msg = fmt.Sprintf(":x: Left guild **%s** :(", common.ReplaceServerInvites(guildData.Name, int64(confBotLeavesJoins.GetInt()), "[removed-server-invite]"))
 	case eventsystem.EventNewGuild:
-		msg = fmt.Sprintf(":white_check_mark: Joined guild **%s** :D", evt.GuildCreate().Guild.Name)
+		msg = fmt.Sprintf(":white_check_mark: Joined guild **%s** :D", common.ReplaceServerInvites(evt.GuildCreate().Guild.Name, int64(confBotLeavesJoins.GetInt()), "[removed-server-invite]"))
 	}
 
 	msg += fmt.Sprintf(" (now connected to %d servers)", count)


### PR DESCRIPTION
Guild names can be server invites, which allows people to promote their servers in the join-logs. This PR fixes just that, by replacing server invites with the text `[removed-server-invite]`, as seen in the image below:
![image](https://user-images.githubusercontent.com/67655446/122669299-fafeee00-d1bc-11eb-939d-44f83ad62f3a.png)


