### PR TITLE
Docker Improvements again

### DIFF
--- a/yagpdb_docker/Dockerfile
+++ b/yagpdb_docker/Dockerfile
@@ -3,17 +3,13 @@ FROM golang:stretch as builder
 WORKDIR /appbuild/yagpdb
 COPY go.mod go.sum .
 RUN go mod download
+
+# Handle templates for plugins automatically
+COPY */assets/*.html cmd/yagpdb/templates/plugins/
 COPY . .
 
-WORKDIR /bin/yagpdb
-COPY cmd/yagpdb/posts posts/
-COPY cmd/yagpdb/static static/
-COPY cmd/yagpdb/templates templates/
-# Handle templates for plugins automatically
-COPY */assets/*.html templates/plugins/
-
 WORKDIR /appbuild/yagpdb/cmd/yagpdb
-RUN CGO_ENABLED=0 GOOS=linux go build -ldflags "-X github.com/jonas747/yagpdb/common.VERSION=$(git describe --tags)" -v -o /bin/yagpdb
+RUN CGO_ENABLED=0 GOOS=linux go build -v -ldflags "-X github.com/jonas747/yagpdb/common.VERSION=$(git describe --tags)"
 
 
 
@@ -23,13 +19,12 @@ WORKDIR /app
 VOLUME ["/app/soundboard", "/app/cert"]
 EXPOSE 80 443
 
-# We need the X.509 certificates for client TLS to work.
-# Also install tzdata, needed for Go timezone support,
-# and ffmpeg for soundboard support,
-# as the alpine image does not come with them by default.
+# Dependencies: ca-certificates for client TLS, tzdata for timezone and ffmpeg for soundboard support
 RUN apk --no-cache add ca-certificates ffmpeg tzdata
 
-COPY --from=builder /bin/yagpdb .
+COPY --from=builder /appbuild/yagpdb/cmd/yagpdb/static static/
+COPY --from=builder /appbuild/yagpdb/cmd/yagpdb/templates templates/
+COPY --from=builder /appbuild/yagpdb/cmd/yagpdb/yagpdb yagpdb
 
 ENTRYPOINT ["/app/yagpdb"]
 CMD ["-all", "-pa", "-exthttps=false", "-https=true"]

--- a/yagpdb_docker/Dockerfile
+++ b/yagpdb_docker/Dockerfile
@@ -1,7 +1,7 @@
 FROM golang:stretch as builder
 
 WORKDIR /appbuild/yagpdb
-COPY go.mod go.sum .
+COPY go.mod go.sum ./
 RUN go mod download
 
 # Handle templates for plugins automatically

--- a/yagpdb_docker/app.example.env
+++ b/yagpdb_docker/app.example.env
@@ -39,10 +39,10 @@ YAGPDB_AYLIENAPPID=aylien app id here
 YAGPDB_AYLIENAPPKEY=aylien app key here
 
 #Twitter
-YAGPDB_TWITTER_ACCESS_TOKEN=Twitter Access Token
-YAGPDB_TWITTER_ACCESS_TOKEN_SECRET=Twitter Access Token Secret
-YAGPDB_TWITTER_CONSUMER_KEY=Twitter Consumer Key
-YAGPDB_TWITTER_CONSUMER_SECRET=Twitter Consumer Secret
+#YAGPDB_TWITTER_ACCESS_TOKEN=Twitter Access Token
+#YAGPDB_TWITTER_ACCESS_TOKEN_SECRET=Twitter Access Token Secret
+#YAGPDB_TWITTER_CONSUMER_KEY=Twitter Consumer Key
+#YAGPDB_TWITTER_CONSUMER_SECRET=Twitter Consumer Secret
 
 # Reddit
 YAGPDB_REDDIT_CLIENTID=Reddit application clientid here


### PR DESCRIPTION
Dockerfile:
- Revert the move of copy operations to builder from the last Docker Improvements PR  #982, and instead run them in the final image again to make use of image layer download caching. 
Having separate image layers for static/ and templates/ in the final image allows us to cache these when pulling new images from Dockerhub. This means we only need to re-download the image layer with the binary and don't need to re-download the image layers for static/ and templates/ if they weren't changed.
This reduces the total download traffic when pulling new images, due to static being close to the size of the binary itself.
- However, we leave the copy-templates operation in the builder so we only have one image layer for all templates.
- And we remove yagpdb/cmd/yagpdb/posts due to it being obsolete.

- Reduced the wall of text for the RUN apk comment to acceptable levels.
- Moved the "-v" option in docker build in front of "-ldflags" for better readability.



app.example.env:
- Commented out Twitter credentials, due to them causing the bot to error out if not edited and run with the default placeholder keys. (cmd/yagpdb/sampleenvfile already has it like this)