### PR TITLE
web: Reword helper texts to link to documentation instead

### DIFF
--- a/cmd/yagpdb/templates/cp_main.html
+++ b/cmd/yagpdb/templates/cp_main.html
@@ -185,7 +185,7 @@ For example, to mention a user, you would do <code><@{{"{{"}}.User.ID{{"}}"}}></
 {{end}}
 
 {{/*Specific template helpers*/}}
-{{define "template_helper_user"}}<code>{{"{{"}}.User.(ID/Username/Mention/Discriminator/Bot){{"}}"}}</code>{{end}}
-{{define "template_helper_guild"}}<code>{{"{{"}}.Server.(ID/Name/Icon/Owner/Permissions){{"}}"}}</code>{{end}}
+{{define "template_helper_user"}}<code>{{"{{"}}.User{{"}}"}}: <a href="https://docs.yagpdb.xyz/reference/templates#user"><code>.User</code> object documentation.</a></code>{{end}}
+{{define "template_helper_guild"}}<code>{{"{{"}}.Guild{{"}}"}}<a href="https://docs.yagpdb.xyz/reference/templates#guild-server"><code>.Guild</code> object reference.</a></code>{{end}}
 
 {{define "set_roles"}}<script>var activeGuildRoles = JSON.parse('{{json .ActiveGuild.Roles}}');</script>{{end}}

--- a/moderation/assets/moderation.html
+++ b/moderation/assets/moderation.html
@@ -1,5 +1,5 @@
-{{define "template_helper_mod_author"}}<code>{{"{{"}}.Author.(Username/ID/Discriminator){{"}}"}}</code> - The author of
-the punishment{{end}}
+{{define "template_helper_mod_author"}}<code>{{"{{"}}.Author{{"}}"}}</code> - The author of
+the punishment, is an <a href="https://docs.yagpdb.xyz/reference/templates#user"><code>.User</code> object. </a>{{end}}
 
 {{define "cp_moderation"}}
 {{template "cp_head" .}}


### PR DESCRIPTION
As not few people are regularly confused over the admittedly strange syntax in the helper texts for the template fields found underneath
* Moderation DM fields
* Join / Leave Feed/DM

will this PR aim to make the phrasing clearer by simply showing the object and linking directly to the template reference of said object: (example taken from the moderation page):

> `{{.User}}`: `.User` object documentation - the user being muted

As usual, should I've forgotten an edit, please do not hesitate to mention that. I've tested my changes on an selfhosted instance and as far as I can tell, everything works just as fine as it did before.

---
Related issue:
- [x] #997 