### PR TITLE
moderation: show server warning count

### DIFF
--- a/moderation/commands.go
+++ b/moderation/commands.go
@@ -859,7 +859,10 @@ var ModerationCommands = []*commands.YAGCommand{
 					out += fmt.Sprintf("#%02d: %4d - %d\n", v.Rank, v.WarnCount, v.UserID)
 				}
 			}
-			out += "```\n"
+			var count int
+			common.GORM.Table("moderation_warnings").Where("guild_id = ?", parsed.GuildData.GS.ID).Count(&count)
+
+			out += "```\n" + fmt.Sprintf("Total Server Warnings: `%d`", count)
 
 			embed.Description = out
 


### PR DESCRIPTION
Suggested this a while back, then left it for whatever reason. Saw mrbentarikau added it to his bot (thanks btw, appreciate it :+1: )

Thought this might be something nice to see, before people go ahead and nuke all server warnings via the control panel.
To eliminate some confusion back in `#suggestion-discussion` on the support server, as my phrasing was a bit off there:
This will only show the warnings on the current server, not all total warnings across all +2M servers.

Thanks in advance!