### PR TITLE
templates: Expose `HasPrefix` and `HasSuffix` from the Go library

### DIFF
--- a/common/templates/context.go
+++ b/common/templates/context.go
@@ -42,6 +42,8 @@ var (
 		"urlescape": url.PathEscape,
 		"split":     strings.Split,
 		"title":     strings.Title,
+		"hasPrefix": strings.HasPrefix,
+		"hasSuffix": strings.HasSuffix,
 
 		// math
 		"add":               add,


### PR DESCRIPTION
This was a suggestion on the support server, exposing the inbuilt functions `HasPrefix` and `HasSuffix` from the Go `strings` library.

As far as I can tell, it works fine on selfhost - this is the first time that I added things to the scripting language, so any advice / tips are highly appreciated.

Thanks in advance!