### PR TITLE
stdcommands: add switch to weather cmd to change the unit system

### DIFF
--- a/stdcommands/weather/weather.go
+++ b/stdcommands/weather/weather.go
@@ -23,14 +23,24 @@ var Command = &commands.YAGCommand{
 	RunInDM:      true,
 	RequiredArgs: 1,
 	Arguments: []*dcmd.ArgDef{
-		&dcmd.ArgDef{Name: "Where", Type: dcmd.String},
+		{Name: "Where", Type: dcmd.String},
+	},
+	ArgSwitches: []*dcmd.ArgDef{
+		{Name: "imperial", Help: "Change units to imperial"},
 	},
 	DefaultEnabled:      true,
 	SlashCommandEnabled: true,
 	RunFunc: func(data *dcmd.Data) (interface{}, error) {
 		where := data.Args[0].Str()
+		// use metrics as forced default
+		unit := "m"
 
-		req, err := http.NewRequest("GET", "http://wttr.in/"+where+"?m", nil)
+		// switch to imperial units - blame the API for that strange choice of "u"
+		if data.Switches["imperial"].Value != nil {
+			unit = "u"
+		}
+
+		req, err := http.NewRequest("GET", "http://wttr.in/"+where+"?"+unit, nil)
 		if err != nil {
 			return nil, err
 		}


### PR DESCRIPTION
Small one, but fairly frequent request to please use imperial units for the weather command.
Reading through the API's documentation, this is more than doable: just change the unit parameter from `m` to `u`.

This pull request will add a switch `imperial` to the command, which then allows users to change the unit system from metric to imperial. Backwards compatibility is therefore kept.

As far as I can tell, everything works fine on a selfhost:

![screenshot](https://user-images.githubusercontent.com/71897876/125691053-cdc88c01-cddd-459c-afa3-649df8dfb1a3.png)
