### PR TITLE
premium: remove old payment methods from the dashboard

### DIFF
--- a/premium/assets/premium.html
+++ b/premium/assets/premium.html
@@ -36,18 +36,6 @@
                                 <li>Make a pledge on my <a href="https://patreon.com/yagpdb">Patreon</a>. Tiers above $3
                                     will grant you premium slots. It will take 2 minutes from you make a pledge to it
                                     being processed here.</li>
-                                <li>Other payment methods are also accepted, but requires manual intervention from me.
-                                    Full list: Paypal, Bitcoin, Bitcoin Cash, Ethereum, Litecoin and IOTA. Please see
-                                    the pricing below and contact me if you wanna donate using one of these methods
-                                    (pricing is monthly).
-                                    <ul>
-                                        <li>$3 = 1 premium slot</li>
-                                        <li>$5 = 2 premium slots</li>
-                                        <li>$7.50 = 3 premium slots</li>
-                                        <li>$10 = 5 premium slots</li>
-                                        <li>Anything above $10: 1 premium slot per $2</li>
-                                    </ul>
-                                </li>
                             </ul>
                         </div>
                     </section>


### PR DESCRIPTION
Since other payment methods are no longer accepted, this PR removes
- the alternate methods that were accepted earlier. 
- the pricing information which can directly be seen on the Patreon page along with the benefits they offer, in a much better fashion.