### PR TITLE
wyr: hotfix formatting

### DIFF
--- a/stdcommands/wouldyourather/wouldyourather.go
+++ b/stdcommands/wouldyourather/wouldyourather.go
@@ -26,7 +26,7 @@ var Command = &commands.YAGCommand{
 		}
 
 		embed := &discordgo.MessageEmbed{
-			Description: fmt.Sprintf("**EITHER...***🇦: %s\n\n**OR...**\n🇧 %s", q1, q2),
+			Description: fmt.Sprintf("**EITHER...**\n🇦: %s\n\n**OR...**\n🇧 %s", q1, q2),
 			Author: &discordgo.MessageEmbedAuthor{
 				Name:    "Would you rather...",
 				URL:     "https://either.io/",


### PR DESCRIPTION
Misses a newline and had one asterisk `*` too much. This PR fixes that.