### PR TITLE
cc: fix showing trigger for non-text types

### DIFF
--- a/customcommands/bot.go
+++ b/customcommands/bot.go
@@ -247,8 +247,8 @@ func FindCommands(ccs []*models.CustomCommand, data *dcmd.Data) (foundCCS []*mod
 func StringCommands(ccs []*models.CustomCommand, gMap map[int64]string) string {
 	out := ""
 	for _, cc := range ccs {
-		switch cc.TextTrigger {
-		case "":
+		switch {
+		case cc.TriggerType >= 5:
 			out += fmt.Sprintf("`#%3d:` %s - Group: `%s`\n", cc.LocalID, CommandTriggerType(cc.TriggerType).String(), gMap[cc.GroupID.Int64])
 		default:
 			out += fmt.Sprintf("`#%3d:` `%s`: %s - Group: `%s`\n", cc.LocalID, cc.TextTrigger, CommandTriggerType(cc.TriggerType).String(), gMap[cc.GroupID.Int64])


### PR DESCRIPTION
Continuation of #943. This fixed it for running `-cc` with a specific command, but `-cc` still had the same issue:

![image](https://user-images.githubusercontent.com/56809242/125838526-e118c794-950a-471f-a969-46273d0a85cf.png)

To rectify this, apply a similar fix to the one in the PR mentioned to `StringCommands`.
The current check is inadequate as the `TextTrigger` field is not cleared when the trigger type is changed.